### PR TITLE
fix: Correct message CMS field setup

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -19,12 +19,13 @@ collections:
     label: "Message"
     folder: "content/message"
     create: true
+    identifier_field: "forwarded-from"
     fields:
-      - { label: "Section", name: "section", widget: "select", options: ["section-one", "section-six"] }
+      - { label: "Section", name: "section", widget: "select", options: ["section-one", "section-seven", "section-eleven"] }
       - { label: "Date & time", name: "datetime", widget: "datetime" }
-      - { label: "Forwarded from", name: "forwarded-from", widget: "string", required: false }
+      - { label: "Forwarded from", name: "forwarded-from", widget: "string" }
       - { label: "Body", name: "body", widget: "markdown" }
-      - { label: "View count", name: "view-count", widget: "number", required: false }
+      - { label: "View count", name: "view-count", widget: "number" }
       - { label: "Avatar icon", name: "avatar-src", widget: "image" }
 
   - name: "image"


### PR DESCRIPTION
Fixes #44

## Description

- Messages titled by forwarded by
- Messages do not have optional fields
- Messages can be added to sections 1,7 & 11
