### PR TITLE
Feat/11 data loss portraits gradually fade in

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -12,6 +12,7 @@
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",
             "elm/json": "1.1.3",
+            "elm/random": "1.0.0",
             "elm/svg": "1.0.1",
             "elm/time": "1.0.0",
             "rl-king/elm-inview": "2.0.1",
@@ -38,8 +39,7 @@
             "elm-explorations/test": "2.1.1"
         },
         "indirect": {
-            "elm/bytes": "1.0.8",
-            "elm/random": "1.0.0"
+            "elm/bytes": "1.0.8"
         }
     }
 }

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -9,6 +9,7 @@ import Html.Attributes
 import InView
 import Model exposing (Model)
 import Msg exposing (Msg(..))
+import Random
 import View
 
 
@@ -35,10 +36,14 @@ init flags =
             InView.init InViewMsg trackable
     in
     ( { content = Data.decodedContent flags
+      , randomIntList = []
       , inView = inViewModel
       , chartHovering = []
       }
-    , inViewCmds
+    , Cmd.batch
+        [ Random.generate NewRandomIntList generateRandomIntList
+        , inViewCmds
+        ]
     )
 
 
@@ -52,6 +57,11 @@ subscriptions model =
 
 update msg model =
     case msg of
+        NewRandomIntList newRandomIntList ->
+            ( { model | randomIntList = newRandomIntList }
+            , Cmd.none
+            )
+
         OnScroll offset ->
             ( { model | inView = InView.updateViewportOffset offset model.inView }
             , Cmd.none
@@ -89,3 +99,8 @@ viewDocument model =
             (View.viewSections model)
         ]
     }
+
+
+generateRandomIntList : Random.Generator (List Int)
+generateRandomIntList =
+    Random.list 865 (Random.int 0 100)

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -29,11 +29,14 @@ main =
 init : Data.Flags -> ( Model, Cmd Msg )
 init flags =
     let
-        trackable =
+        trackableImages =
             Data.trackableIdListFromFlags flags
 
+        trackableSections =
+            [ "section-8" ]
+
         ( inViewModel, inViewCmds ) =
-            InView.init InViewMsg trackable
+            InView.init InViewMsg (trackableImages ++ trackableSections)
     in
     ( { content = Data.decodedContent flags
       , randomIntList = []

--- a/src/elm/Model.elm
+++ b/src/elm/Model.elm
@@ -7,6 +7,7 @@ import InView
 
 type alias Model =
     { content : Data.Content
+    , randomIntList : List Int
     , inView : InView.State
     , chartHovering : List (Chart.Item.One Data.LineChartDatum Chart.Item.Dot)
     }

--- a/src/elm/Msg.elm
+++ b/src/elm/Msg.elm
@@ -6,7 +6,8 @@ import InView
 
 
 type Msg
-    = OnScroll { x : Float, y : Float }
+    = NewRandomIntList (List Int)
+    | OnScroll { x : Float, y : Float }
     | InViewMsg InView.Msg
     | OnElementLoad String
     | OnChartHover (List (Chart.Item.One Data.LineChartDatum Chart.Item.Dot))

--- a/src/elm/View/Section8.elm
+++ b/src/elm/View/Section8.elm
@@ -13,23 +13,24 @@ view : Model -> List (Html.Html Msg)
 view model =
     [ Html.h2 []
         [ Html.text "Section 8 - 2000 images with tickers"
-        , viewPortraitList
+        , viewPortraitList model.randomIntList
         ]
     ]
 
 
-viewPortraitList : Html.Html Msg
-viewPortraitList =
+viewPortraitList : List Int -> Html.Html Msg
+viewPortraitList randomIntList =
     Html.div [ Html.Attributes.class "portraits" ]
-        (List.map
-            (\count ->
-                animatedImg (fadeIn (count * 100))
+        (List.map2
+            (\count randomInt ->
+                animatedImg (fadeIn ((randomInt * 100) + count * 10))
                     [ Html.Attributes.src (jpgSrcFromInt count)
                     , Html.Attributes.class "portrait"
                     ]
                     []
             )
             (List.range 0 865)
+            randomIntList
         )
 
 
@@ -49,8 +50,6 @@ fadeIn delay =
         { duration = 6000
         , options =
             [ Simple.Animation.delay delay
-            , Simple.Animation.loop
-            , Simple.Animation.yoyo
             ]
         }
         [ Simple.Animation.Property.opacity 0 ]

--- a/src/elm/View/Section8.elm
+++ b/src/elm/View/Section8.elm
@@ -2,6 +2,7 @@ module View.Section8 exposing (view)
 
 import Html
 import Html.Attributes
+import InView
 import Model exposing (Model)
 import Msg exposing (Msg)
 import Simple.Animation
@@ -11,9 +12,18 @@ import Simple.Animation.Property
 
 view : Model -> List (Html.Html Msg)
 view model =
+    let
+        sectionInView =
+            InView.isInOrAboveView "section-8" model.inView
+                |> Maybe.withDefault False
+    in
     [ Html.h2 []
         [ Html.text "Section 8 - 2000 images with tickers"
-        , viewPortraitList model.randomIntList
+        , if sectionInView then
+            viewPortraitList model.randomIntList
+
+          else
+            Html.text ""
         ]
     ]
 

--- a/tests/Views.elm
+++ b/tests/Views.elm
@@ -50,6 +50,7 @@ suite =
                 , images = []
                 , graphs = []
                 }
+            , randomIntList = []
             , inView = inViewModel
             , chartHovering = []
             }


### PR DESCRIPTION
Fixes #11

## Description

- Images start to randomly fade in once the whole section is reached.
- This is a first pass. There will be improvements. e.g. We might chunk into sections of 100 so the bottom ones's don't start loading when the top is reached. Currently we cludge this by weighting the fade in time by image count.
