### PR TITLE
Improve scroll behaviour of terminal

### DIFF
--- a/src/elm/Msg.elm
+++ b/src/elm/Msg.elm
@@ -8,7 +8,8 @@ import Time
 
 
 type Msg
-    = Tick Time.Posix
+    = NoOp
+    | Tick Time.Posix
     | NewRandomIntList (List Int)
     | OnScroll { x : Float, y : Float }
     | InViewMsg InView.Msg
@@ -17,3 +18,4 @@ type Msg
     | OnChartHover (List (Chart.Item.One Data.LineChartDatum Chart.Item.Dot))
     | ChangeCommand String
     | SubmitCommand String
+    | ScrollResult (Result Browser.Dom.Error ())

--- a/src/elm/View/Section6.elm
+++ b/src/elm/View/Section6.elm
@@ -40,7 +40,10 @@ viewTerminal model =
                     , commandList = []
                     }
     in
-    Html.div [ Html.Attributes.class "terminal" ]
+    Html.div
+        [ Html.Attributes.id "terminal-output"
+        , Html.Attributes.class "terminal"
+        ]
         [ Html.h3 [] [ Html.text (String.replace "-" " " terminalId) ]
         , Html.p [] [ Html.text welcomeMessage ]
         , viewOutput prompt model.terminalState.history commandList
@@ -68,7 +71,9 @@ viewPrompt prompt =
         machineName =
             Maybe.withDefault "bi4c8d" (List.head (List.reverse promptParts)) |> String.replace "$" ""
     in
-    Html.span [ Html.Attributes.class "prompt" ]
+    Html.span
+        [ Html.Attributes.class "prompt"
+        ]
         [ Html.span [ Html.Attributes.class "user-name" ] [ Html.text userName ]
         , Html.text "@"
         , Html.span [ Html.Attributes.class "machine-name" ] [ Html.text machineName ]


### PR DESCRIPTION
Fixes #180
Not perfect, but parking for now.

TODO fix scroll position if container is scrolled past. If using the terminal naturally from the inside, it works but if you leave the terminal div and scroll than main position then go back and type, it scrolls too far down.


## Description

- scrolls to bottom of container when command is executed
