### PR TITLE
Add link text copy to message sections

### DIFF
--- a/src/elm/Copy/Keys.elm
+++ b/src/elm/Copy/Keys.elm
@@ -8,7 +8,9 @@ type Key
       -- Message
     | Section8Heading
     | Section10MessageHeading
+    | Section10MessageTranscriptLink
     | Section11MessageHeading
+    | Section11MessageTranscriptLink
       -- Breaches
     | TotalBreachesSinceView Int
       -- Terminal

--- a/src/elm/Copy/Text.elm
+++ b/src/elm/Copy/Text.elm
@@ -23,8 +23,14 @@ t key =
         Section10MessageHeading ->
             "LockBit"
 
+        Section10MessageTranscriptLink ->
+            "[LockBit message transcripts](https://lockbittranscripturi)"
+
         Section11MessageHeading ->
-            ""
+            "Hackney"
+
+        Section11MessageTranscriptLink ->
+            "[Hackney message transcripts](https://hackneytranscripturi)"
 
         TotalBreachesSinceView count ->
             String.join " "

--- a/src/elm/View/Messages.elm
+++ b/src/elm/View/Messages.elm
@@ -8,8 +8,8 @@ import Msg exposing (Msg)
 import Time
 
 
-view : Data.SectionId -> List Data.Message -> String -> Html.Html Msg
-view sectionId messageList title =
+view : Data.SectionId -> List Data.Message -> String -> String -> Html.Html Msg
+view sectionId messageList title transcriptLinkMarkdown =
     if List.length messageList > 0 then
         Html.div [ Html.Attributes.class "messages" ]
             [ Html.h3 [] [ Html.text title ]
@@ -22,6 +22,7 @@ view sectionId messageList title =
                     (Data.filterBySection sectionId messageList)
                     |> List.concat
                 )
+            , Html.p [] (Markdown.markdownToHtml transcriptLinkMarkdown)
             ]
 
     else

--- a/src/elm/View/Section10.elm
+++ b/src/elm/View/Section10.elm
@@ -12,5 +12,5 @@ import View.Messages
 
 view : Model -> List (Html.Html Msg)
 view model =
-    [ View.Messages.view Data.Section10 model.content.messages (t Section10MessageHeading)
+    [ View.Messages.view Data.Section10 model.content.messages (t Section10MessageHeading) (t Section10MessageTranscriptLink)
     ]

--- a/src/elm/View/Section11.elm
+++ b/src/elm/View/Section11.elm
@@ -14,6 +14,6 @@ import View.Posts
 view : Model -> List (Html.Html Msg)
 view model =
     [ View.MainText.viewTop Data.Section11 model.content.mainText
-    , View.Messages.view Data.Section11 model.content.messages (t Section11MessageHeading)
+    , View.Messages.view Data.Section11 model.content.messages (t Section11MessageHeading) (t Section11MessageTranscriptLink)
     , View.Posts.view Data.Section11 model.content.posts
     ]


### PR DESCRIPTION
Fixes #195 

## Description

- Add copy key and render for message sections to have transcription links
