### PR TITLE
fix: Video and view count optional on Post

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -25,9 +25,9 @@ collections:
       - { label: "Date & time", name: "datetime", widget: "datetime" }
       - { label: "Forwarded from", name: "forwarded-from", widget: "string" }
       - { label: "Body", name: "body", widget: "markdown" }
-      - { label: "View count", name: "view-count", widget: "number" }
+      - { label: "View count", name: "view-count", widget: "number", required: false }
       - { label: "Avatar icon", name: "avatar-src", widget: "image" }
-      - { label: "Video embed src", name: "video-src", widget: "string" }
+      - { label: "Video embed src", name: "video-src", widget: "string", required: false }
 
   - name: "message"
     label: "Message"

--- a/src/elm/Data.elm
+++ b/src/elm/Data.elm
@@ -32,7 +32,7 @@ type alias Post =
     { section : SectionId
     , datetime : Time.Posix
     , forwardedFrom : String
-    , viewCount : Int
+    , maybeViewCount : Maybe Int
     , avatarSrc : String
     , maybeVideo : Maybe String
     , body : String
@@ -240,7 +240,7 @@ postDecoder =
             |> Json.Decode.andThen posixFromStringDecoder
         )
         (Json.Decode.field "forwarded-from" Json.Decode.string)
-        (Json.Decode.field "view-count" Json.Decode.int)
+        (Json.Decode.maybe (Json.Decode.field "view-count" Json.Decode.int))
         (Json.Decode.field "avatar-src" Json.Decode.string)
         (Json.Decode.maybe (Json.Decode.field "video-src" Json.Decode.string))
         (Json.Decode.field "content" Json.Decode.string)

--- a/src/elm/View/Posts.elm
+++ b/src/elm/View/Posts.elm
@@ -62,7 +62,12 @@ viewPost post isFirst =
             , Html.div [ Html.Attributes.class "post-body" ]
                 (viewVideo post.maybeVideo :: Markdown.markdownToHtml post.body)
             , Html.div [ Html.Attributes.class "post-meta-info" ]
-                [ Html.span [ Html.Attributes.class "post-view-count" ] [ viewPostViewCount post.viewCount ]
+                [ case post.maybeViewCount of
+                    Just aViewCount ->
+                        Html.span [ Html.Attributes.class "post-view-count" ] [ viewPostViewCount aViewCount ]
+
+                    Nothing ->
+                        Html.text ""
                 , Html.span [ Html.Attributes.class "post-time" ] [ viewPostTime post.datetime ]
                 ]
             ]


### PR DESCRIPTION
Fixes #211 

## Description

- Makes video optional on post
- Makes view count optional on post

@stuartleech If there is no view count at the moment, I am not showing icon and number at all. Should it rather be shown as zero if it's not there?
