### PR TITLE
pile of draggable content

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -16,19 +16,24 @@
             "elm/svg": "1.0.1",
             "elm/time": "1.0.0",
             "elm-community/html-extra": "3.4.0",
+            "elm-explorations/linear-algebra": "1.0.3",
             "rl-king/elm-inview": "2.0.1",
             "rtfeldman/elm-iso8601-date-strings": "1.1.4",
-            "terezka/elm-charts": "4.0.0"
+            "terezka/elm-charts": "4.0.0",
+            "zaboco/elm-draggable": "5.0.0"
         },
         "indirect": {
             "K-Adam/elm-dom": "1.0.0",
             "danhandrea/elm-time-extra": "1.1.0",
+            "elm/bytes": "1.0.8",
+            "elm/file": "1.0.5",
             "elm/parser": "1.1.0",
             "elm/regex": "1.0.0",
             "elm/url": "1.0.0",
             "elm/virtual-dom": "1.0.3",
             "justinmimbs/date": "4.1.0",
             "justinmimbs/time-extra": "1.2.0",
+            "mpizenberg/elm-pointer-events": "4.0.2",
             "myrho/elm-round": "1.0.5",
             "rtfeldman/elm-hex": "1.0.0",
             "ryan-haskell/date-format": "1.0.0",
@@ -39,8 +44,6 @@
         "direct": {
             "elm-explorations/test": "2.1.1"
         },
-        "indirect": {
-            "elm/bytes": "1.0.8"
-        }
+        "indirect": {}
     }
 }

--- a/elm.json
+++ b/elm.json
@@ -17,6 +17,7 @@
             "elm/time": "1.0.0",
             "elm-community/html-extra": "3.4.0",
             "elm-explorations/linear-algebra": "1.0.3",
+            "pzp1997/assoc-list": "1.0.0",
             "rl-king/elm-inview": "2.0.1",
             "rtfeldman/elm-iso8601-date-strings": "1.1.4",
             "terezka/elm-charts": "4.0.0",

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -4,10 +4,10 @@
   --grey-light: #d9d9d9;
   --grey-dark: #a9a4a4;
 
-  --red: #E4003B;
-  --blue: #0087DC;
-  --green: #33FF00;
-  
+  --red: #e4003b;
+  --blue: #0087dc;
+  --green: #33ff00;
+
   --default-radius: 30px;
   --max-section-width: 800px;
 }
@@ -46,8 +46,8 @@ p {
 #section-eleven,
 #section-twelve,
 #section-fourteen {
- max-width: 100%;
- width: 100%;
+  max-width: 100%;
+  width: 100%;
 }
 
 #section-eleven h2.heading {
@@ -75,7 +75,7 @@ p {
   border: solid var(--black) 1px;
   border-radius: var(--default-radius);
   padding: 30px 30px 20px 30px;
-  text-align: left
+  text-align: left;
 }
 
 .main-text-title {
@@ -197,7 +197,7 @@ p {
 }
 
 .message-bubble {
- position: relative;
+  position: relative;
 }
 
 .typing-dots {
@@ -353,13 +353,13 @@ p {
   padding: 4.5rem 0;
 }
 
-.terminal{
+.terminal {
   border: 2px solid var(--grey-dark);
   height: 100%;
   margin: 0 auto;
   max-width: var(--max-section-width);
   overflow: auto;
-  text-align:left;
+  text-align: left;
 }
 
 .terminal h3 {
@@ -432,7 +432,7 @@ p {
 }
 
 .terminal .help li .command-name::after {
-  content: ":"
+  content: ":";
 }
 
 .terminal .error {
@@ -460,4 +460,25 @@ h2.final-ticker {
   flex-direction: column;
   justify-content: center;
   margin: 10px auto;
+}
+
+/** Draggable Pile **/
+
+.pile {
+  position: relative;
+  height: 100vh;
+  width: 100vw;
+}
+
+/* debugging styles */
+.card {
+  position: absolute;
+  background-color: yellow;
+  padding: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 5rem;
+  font-weight: bold;
+  border: 5px solid black;
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -99,6 +99,7 @@ p {
 }
 
 .post {
+  background: var(--white);
   align-items: center;
   display: flex;
   flex-direction: column;
@@ -113,7 +114,12 @@ p {
   padding: 10px 20px;
 }
 
+#section-ten .post {
+  background: var(--black);
+}
+
 #section-ten .post-inner {
+  background: var(--black);
   border: solid var(--white) 1px;
   color: var(--white);
 }
@@ -468,17 +474,10 @@ h2.final-ticker {
   position: relative;
   height: 100vh;
   width: 100vw;
+  overflow: hidden;
 }
 
 /* debugging styles */
 .card {
   position: absolute;
-  background-color: yellow;
-  padding: 1.5rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 5rem;
-  font-weight: bold;
-  border: 5px solid black;
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -170,6 +170,7 @@ p {
 
 /* Video */
 .video-container {
+  background-color: black;
   height: 0px;
   margin-bottom: 2em;
   padding-top: 56.25%;
@@ -477,8 +478,13 @@ h2.final-ticker {
 /** Draggable Pile **/
 
 .pile {
+  margin-top: 5rem;
+  border-top: 1px solid var(--black);
+  border-bottom: 1px solid var(--black);
   height: 100vh;
-  margin-left: calc(50% - 50vw);
+  /* https://piccalil.li/blog/creating-a-full-bleed-css-utility */
+  margin-left: calc(50% - 50vw); /* getting overflow on chrome */
+  margin-right: calc(50% - 50vw); /* getting overflow on chrome */
   overflow: hidden;
   position: relative;
   width: 100vw;
@@ -491,4 +497,59 @@ h2.final-ticker {
 .image-constraint {
   height: 60vh;
   width: 40vw;
+}
+
+.post-draggable {
+  background-color: var(--white);
+  box-shadow: 0 3px 10px rgb(0 0 0 / 0.3);
+  display: grid;
+  font-family: monospace;
+  font-size: 1rem;
+  gap: 1rem;
+  padding: 1rem 2rem;
+  grid-template-columns: max-content 1fr;
+  grid-template-rows: auto;
+  grid-template-areas:
+    "avatar forwardedFrom"
+    "empty content"
+    "empty meta";
+  width: 520px;
+}
+
+.post-avatar-draggable {
+  grid-area: avatar;
+}
+
+.post-forwarded-from-draggable {
+  grid-area: forwardedFrom;
+  padding-top: 0.25rem;
+}
+
+.post-content-draggable {
+  grid-area: content;
+  text-align: left;
+}
+
+.post-meta-draggable {
+  display: flex;
+  flex-direction: row-reverse;
+  grid-area: meta;
+  justify-content: space-between;
+}
+
+.post-view-count-draggable {
+  position: relative;
+  margin-left: 2rem;
+}
+.post-view-count-draggable::before {
+  display: inline-block;
+  position: absolute;
+  content: url(/images/eye.svg);
+  left: -2rem;
+  top: -0.35rem;
+}
+
+.post-date-time-draggable {
+  display: flex;
+  gap: 0.5rem;
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -489,6 +489,6 @@ h2.final-ticker {
 }
 
 .image-constraint {
-  max-width: 40vw;
-  max-height: 60vh;
+  height: 60vh;
+  width: 40vw;
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -13,6 +13,7 @@
 }
 
 html body {
+  overflow-x: hidden; /* needed to allow full-bleed elements within sections on chrome */
   color: var(--black);
   font-family: Inter, sans-serif;
 }
@@ -478,13 +479,13 @@ h2.final-ticker {
 /** Draggable Pile **/
 
 .pile {
-  margin-top: 5rem;
-  border-top: 1px solid var(--black);
   border-bottom: 1px solid var(--black);
+  border-top: 1px solid var(--black);
   height: 100vh;
-  /* https://piccalil.li/blog/creating-a-full-bleed-css-utility */
-  margin-left: calc(50% - 50vw); /* getting overflow on chrome */
-  margin-right: calc(50% - 50vw); /* getting overflow on chrome */
+  /* needed to make element use whole width of screen */
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
+  margin-top: 5rem;
   overflow: hidden;
   position: relative;
   width: 100vw;
@@ -506,13 +507,13 @@ h2.final-ticker {
   font-family: monospace;
   font-size: 1rem;
   gap: 1rem;
-  padding: 1rem 2rem;
-  grid-template-columns: max-content 1fr;
-  grid-template-rows: auto;
   grid-template-areas:
     "avatar forwardedFrom"
     "empty content"
     "empty meta";
+  grid-template-columns: max-content 1fr;
+  grid-template-rows: auto;
+  padding: 1rem 2rem;
   width: 520px;
 }
 
@@ -538,14 +539,14 @@ h2.final-ticker {
 }
 
 .post-view-count-draggable {
-  position: relative;
   margin-left: 2rem;
+  position: relative;
 }
 .post-view-count-draggable::before {
-  display: inline-block;
-  position: absolute;
   content: url(/images/eye.svg);
+  display: inline-block;
   left: -2rem;
+  position: absolute;
   top: -0.35rem;
 }
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -477,10 +477,11 @@ h2.final-ticker {
 /** Draggable Pile **/
 
 .pile {
-  position: relative;
   height: 100vh;
-  width: 100vw;
+  margin-left: calc(50% - 50vw);
   overflow: hidden;
+  position: relative;
+  width: 100vw;
 }
 
 .card {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -270,6 +270,12 @@ p {
   position: relative;
 }
 
+.images-mobile {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
 .image {
   position: sticky;
   top: 3rem;
@@ -477,7 +483,11 @@ h2.final-ticker {
   overflow: hidden;
 }
 
-/* debugging styles */
 .card {
   position: absolute;
+}
+
+.image-constraint {
+  max-width: 40vw;
+  max-height: 60vh;
 }

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -50,15 +50,19 @@ init flags =
         ( inViewModel, inViewCmds ) =
             InView.init InViewMsg trackableSections
 
+        content : Data.Content
         content =
             Data.decodedContent flags
 
+        section1draggableContent : ( Data.SectionId, List Pile.Data )
         section1draggableContent =
             ( Data.Section1, content.posts |> Data.filterBySection Data.Section1 |> List.map Pile.Post )
 
+        section4draggableContent : ( Data.SectionId, List Pile.Data )
         section4draggableContent =
             ( Data.Section4, content.images |> Data.filterBySection Data.Section4 |> List.map Pile.Image )
 
+        section10draggableContent : ( Data.SectionId, List Pile.Data )
         section10draggableContent =
             ( Data.Section10, content.posts |> Data.filterBySection Data.Section10 |> List.map Pile.Post )
     in
@@ -91,6 +95,7 @@ subscriptions model =
         ]
 
 
+update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
         NoOp ->

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -56,13 +56,16 @@ init flags =
             Data.decodedContent flags
 
         section1draggableContent =
-            ( Data.Section1, View.Posts.posts Data.Section1 content.posts )
+            -- ( Data.Section1, View.Posts.posts Data.Section1 content.posts )
+            ( Data.Section1, content.posts |> Data.filterBySection Data.Section1 |> List.map Pile.Post )
 
         section4draggableContent =
-            ( Data.Section4, View.StackingImage.viewImageListDraggable Data.Section4 content.images )
+            -- ( Data.Section4, View.StackingImage.viewImageListDraggable Data.Section4 content.images )
+            ( Data.Section4, content.images |> Data.filterBySection Data.Section4 |> List.map Pile.Image )
 
         section10draggableContent =
-            ( Data.Section10, View.Posts.posts Data.Section10 content.posts )
+            -- ( Data.Section10, View.Posts.posts Data.Section10 content.posts )
+            ( Data.Section10, content.posts |> Data.filterBySection Data.Section10 |> List.map Pile.Post )
     in
     ( { time = Time.millisToPosix 0
       , content = content
@@ -75,6 +78,7 @@ init flags =
       , terminalState = { input = "", history = [] }
       , piles = Pile.init [ section1draggableContent, section4draggableContent, section10draggableContent ]
 
+      -- , piles = Pile.init [ section1draggableContent, section4draggableContent, section10draggableContent ]
       -- , pile1 = Pile.init (View.Posts.posts Data.Section1 (Data.decodedContent flags |> (\c -> c.posts)))
       -- , pile2 = Pile.init (View.StackingImage.viewImageListDraggable Data.Section4 (Data.decodedContent flags |> (\c -> c.images)))
       -- , pile3 = Pile.init (View.Posts.posts Data.Section10 (Data.decodedContent flags |> (\c -> c.posts)))

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -16,6 +16,7 @@ import Task
 import Time
 import View
 import View.Posts
+import View.StackingImage
 
 
 port onScroll : ({ x : Float, y : Float } -> msg) -> Sub msg
@@ -61,6 +62,7 @@ init flags =
       , chartHovering = []
       , terminalState = { input = "", history = [] }
       , pile1 = Pile.init (View.Posts.posts Data.Section1 (Data.decodedContent flags |> (\c -> c.posts)))
+      , pile2 = Pile.init (View.StackingImage.viewImageListDraggable Data.Section4 (Data.decodedContent flags |> (\c -> c.images)))
       }
     , Cmd.batch
         [ Random.generate NewRandomIntList generateRandomIntList
@@ -77,6 +79,7 @@ subscriptions model =
         , InView.subscriptions InViewMsg model.inView
         , onScroll OnScroll
         , Pile.subscriptions Pile1 model.pile1
+        , Pile.subscriptions Pile2 model.pile2
         ]
 
 
@@ -184,6 +187,13 @@ update msg model =
                     Pile.update Pile1 msg_ model.pile1
             in
             ( { model | pile1 = pile1 }, cmd )
+
+        Pile2 msg_ ->
+            let
+                ( pile2, cmd ) =
+                    Pile.update Pile2 msg_ model.pile2
+            in
+            ( { model | pile2 = pile2 }, cmd )
 
 
 scrollToElement : String -> Cmd Msg

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -63,6 +63,7 @@ init flags =
       , terminalState = { input = "", history = [] }
       , pile1 = Pile.init (View.Posts.posts Data.Section1 (Data.decodedContent flags |> (\c -> c.posts)))
       , pile2 = Pile.init (View.StackingImage.viewImageListDraggable Data.Section4 (Data.decodedContent flags |> (\c -> c.images)))
+      , pile3 = Pile.init (View.Posts.posts Data.Section10 (Data.decodedContent flags |> (\c -> c.posts)))
       }
     , Cmd.batch
         [ Random.generate NewRandomIntList generateRandomIntList
@@ -80,6 +81,7 @@ subscriptions model =
         , onScroll OnScroll
         , Pile.subscriptions Pile1 model.pile1
         , Pile.subscriptions Pile2 model.pile2
+        , Pile.subscriptions Pile3 model.pile3
         ]
 
 
@@ -194,6 +196,13 @@ update msg model =
                     Pile.update Pile2 msg_ model.pile2
             in
             ( { model | pile2 = pile2 }, cmd )
+
+        Pile3 msg_ ->
+            let
+                ( pile3, cmd ) =
+                    Pile.update Pile3 msg_ model.pile3
+            in
+            ( { model | pile3 = pile3 }, cmd )
 
 
 scrollToElement : String -> Cmd Msg

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -15,8 +15,6 @@ import Random
 import Task
 import Time
 import View
-import View.Posts
-import View.StackingImage
 
 
 port onScroll : ({ x : Float, y : Float } -> msg) -> Sub msg
@@ -56,15 +54,12 @@ init flags =
             Data.decodedContent flags
 
         section1draggableContent =
-            -- ( Data.Section1, View.Posts.posts Data.Section1 content.posts )
             ( Data.Section1, content.posts |> Data.filterBySection Data.Section1 |> List.map Pile.Post )
 
         section4draggableContent =
-            -- ( Data.Section4, View.StackingImage.viewImageListDraggable Data.Section4 content.images )
             ( Data.Section4, content.images |> Data.filterBySection Data.Section4 |> List.map Pile.Image )
 
         section10draggableContent =
-            -- ( Data.Section10, View.Posts.posts Data.Section10 content.posts )
             ( Data.Section10, content.posts |> Data.filterBySection Data.Section10 |> List.map Pile.Post )
     in
     ( { time = Time.millisToPosix 0
@@ -77,11 +72,6 @@ init flags =
       , chartHovering = []
       , terminalState = { input = "", history = [] }
       , piles = Pile.init [ section1draggableContent, section4draggableContent, section10draggableContent ]
-
-      -- , piles = Pile.init [ section1draggableContent, section4draggableContent, section10draggableContent ]
-      -- , pile1 = Pile.init (View.Posts.posts Data.Section1 (Data.decodedContent flags |> (\c -> c.posts)))
-      -- , pile2 = Pile.init (View.StackingImage.viewImageListDraggable Data.Section4 (Data.decodedContent flags |> (\c -> c.images)))
-      -- , pile3 = Pile.init (View.Posts.posts Data.Section10 (Data.decodedContent flags |> (\c -> c.posts)))
       }
     , Cmd.batch
         [ Random.generate NewRandomIntList generateRandomIntList

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -10,6 +10,7 @@ import Html.Attributes
 import InView
 import Model exposing (Model)
 import Msg exposing (Msg(..))
+import Pile
 import Random
 import Task
 import Time
@@ -58,6 +59,7 @@ init flags =
       , viewportHeightWidth = ( 800, 800 )
       , chartHovering = []
       , terminalState = { input = "", history = [] }
+      , pile1 = Pile.init (List.range 0 10 |> List.map (\n -> Html.div [] [ Html.text <| String.fromInt n ]))
       }
     , Cmd.batch
         [ Random.generate NewRandomIntList generateRandomIntList
@@ -73,6 +75,7 @@ subscriptions model =
         [ Time.every 100 Tick -- 10 times per second
         , InView.subscriptions InViewMsg model.inView
         , onScroll OnScroll
+        , Pile.subscriptions Pile1 model.pile1
         ]
 
 
@@ -173,6 +176,13 @@ update msg model =
 
         ScrollResult _ ->
             ( model, Cmd.none )
+
+        Pile1 msg_ ->
+            let
+                ( pile1, cmd ) =
+                    Pile.update Pile1 msg_ model.pile1
+            in
+            ( { model | pile1 = pile1 }, cmd )
 
 
 scrollToElement : String -> Cmd Msg

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -87,7 +87,7 @@ subscriptions model =
         [ Time.every 100 Tick -- 10 times per second
         , InView.subscriptions InViewMsg model.inView
         , onScroll OnScroll
-        , Pile.subscriptions Piles model.piles
+        , Pile.subscriptions model.piles |> Sub.map Piles
         ]
 
 
@@ -192,9 +192,9 @@ update msg model =
         Piles pileMsg ->
             let
                 ( piles, cmd ) =
-                    Pile.update Piles pileMsg model.piles
+                    Pile.update pileMsg model.piles
             in
-            ( { model | piles = piles }, cmd )
+            ( { model | piles = piles }, cmd |> Cmd.map Piles )
 
 
 scrollToElement : String -> Cmd Msg

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -15,6 +15,7 @@ import Random
 import Task
 import Time
 import View
+import View.Posts
 
 
 port onScroll : ({ x : Float, y : Float } -> msg) -> Sub msg
@@ -59,7 +60,7 @@ init flags =
       , viewportHeightWidth = ( 800, 800 )
       , chartHovering = []
       , terminalState = { input = "", history = [] }
-      , pile1 = Pile.init (List.range 0 10 |> List.map (\n -> Html.div [] [ Html.text <| String.fromInt n ]))
+      , pile1 = Pile.init (View.Posts.posts Data.Section1 (Data.decodedContent flags |> (\c -> c.posts)))
       }
     , Cmd.batch
         [ Random.generate NewRandomIntList generateRandomIntList

--- a/src/elm/Model.elm
+++ b/src/elm/Model.elm
@@ -3,6 +3,7 @@ module Model exposing (Model, TerminalState)
 import Chart.Item
 import Data
 import InView
+import Pile
 import Time
 
 
@@ -16,6 +17,7 @@ type alias Model =
     , viewportHeightWidth : ( Float, Float )
     , chartHovering : List (Chart.Item.One Data.LineChartDatum Chart.Item.Dot)
     , terminalState : TerminalState
+    , pile1 : Pile.Model
     }
 
 

--- a/src/elm/Model.elm
+++ b/src/elm/Model.elm
@@ -19,6 +19,7 @@ type alias Model =
     , terminalState : TerminalState
     , pile1 : Pile.Model
     , pile2 : Pile.Model
+    , pile3 : Pile.Model
     }
 
 

--- a/src/elm/Model.elm
+++ b/src/elm/Model.elm
@@ -17,9 +17,7 @@ type alias Model =
     , viewportHeightWidth : ( Float, Float )
     , chartHovering : List (Chart.Item.One Data.LineChartDatum Chart.Item.Dot)
     , terminalState : TerminalState
-    , pile1 : Pile.Model
-    , pile2 : Pile.Model
-    , pile3 : Pile.Model
+    , piles : Pile.Model
     }
 
 

--- a/src/elm/Model.elm
+++ b/src/elm/Model.elm
@@ -18,6 +18,7 @@ type alias Model =
     , chartHovering : List (Chart.Item.One Data.LineChartDatum Chart.Item.Dot)
     , terminalState : TerminalState
     , pile1 : Pile.Model
+    , pile2 : Pile.Model
     }
 
 

--- a/src/elm/Msg.elm
+++ b/src/elm/Msg.elm
@@ -22,3 +22,4 @@ type Msg
     | ScrollResult (Result Browser.Dom.Error ())
     | Pile1 Pile.Msg
     | Pile2 Pile.Msg
+    | Pile3 Pile.Msg

--- a/src/elm/Msg.elm
+++ b/src/elm/Msg.elm
@@ -4,6 +4,7 @@ import Browser.Dom
 import Chart.Item
 import Data
 import InView
+import Pile
 import Time
 
 
@@ -19,3 +20,4 @@ type Msg
     | ChangeCommand String
     | SubmitCommand String
     | ScrollResult (Result Browser.Dom.Error ())
+    | Pile1 Pile.Msg

--- a/src/elm/Msg.elm
+++ b/src/elm/Msg.elm
@@ -21,3 +21,4 @@ type Msg
     | SubmitCommand String
     | ScrollResult (Result Browser.Dom.Error ())
     | Pile1 Pile.Msg
+    | Pile2 Pile.Msg

--- a/src/elm/Msg.elm
+++ b/src/elm/Msg.elm
@@ -20,6 +20,4 @@ type Msg
     | ChangeCommand String
     | SubmitCommand String
     | ScrollResult (Result Browser.Dom.Error ())
-    | Pile1 Pile.Msg
-    | Pile2 Pile.Msg
-    | Pile3 Pile.Msg
+    | Piles Pile.Msg

--- a/src/elm/Pile.elm
+++ b/src/elm/Pile.elm
@@ -151,16 +151,16 @@ init prePiles =
 -- in order to be compatible
 
 
-dragConfig : (Msg -> msg) -> Draggable.Config DragState msg
-dragConfig mainMsg =
+dragConfig : Draggable.Config DragState Msg
+dragConfig =
     Draggable.customConfig
-        [ Draggable.Events.onDragBy (\( dx, dy ) -> Math.Vector2.vec2 dx dy |> OnDragBy |> mainMsg)
-        , Draggable.Events.onDragStart (\a -> a |> StartDragging |> mainMsg)
+        [ Draggable.Events.onDragBy (\( dx, dy ) -> Math.Vector2.vec2 dx dy |> OnDragBy)
+        , Draggable.Events.onDragStart (\a -> a |> StartDragging)
         ]
 
 
-update : (Msg -> msg) -> Msg -> Model -> ( Model, Cmd msg )
-update mainMsg msg ({ piles, activePile } as model) =
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg ({ piles, activePile } as model) =
     case msg of
         OnDragBy delta ->
             ( { model
@@ -197,13 +197,12 @@ update mainMsg msg ({ piles, activePile } as model) =
             )
 
         DragMsg dragMsg ->
-            Draggable.update (dragConfig mainMsg) dragMsg model
+            Draggable.update dragConfig dragMsg model
 
 
-subscriptions : (Msg -> msg) -> Model -> Sub msg
-subscriptions mainMsg { drag } =
+subscriptions : Model -> Sub Msg
+subscriptions { drag } =
     Draggable.subscriptions DragMsg drag
-        |> Sub.map mainMsg
 
 
 cardView : Data.SectionId -> (Data -> Html.Html Msg) -> Card -> Html.Html Msg

--- a/src/elm/Pile.elm
+++ b/src/elm/Pile.elm
@@ -57,12 +57,12 @@ allCards { activeCard, idleCards } =
 
 
 startDragging : Id -> CardPile -> CardPile
-startDragging id pack =
+startDragging id pile =
     let
         ( targetAsList, others ) =
-            List.partition (.id >> (==) id) (allCards pack)
+            List.partition (.id >> (==) id) pile.idleCards
     in
-    { pack
+    { pile
         | idleCards = others
         , activeCard = targetAsList |> List.head
     }

--- a/src/elm/Pile.elm
+++ b/src/elm/Pile.elm
@@ -174,7 +174,10 @@ update msg ({ piles, activePile } as model) =
 
         StartDragging dragState ->
             ( { model
-                | piles = AssocList.update dragState.dictKey (Maybe.map (startDragging dragState.cardId)) piles
+                | piles =
+                    AssocList.update dragState.dictKey
+                        (Maybe.map (\cardPile -> cardPile |> stopDragging |> startDragging dragState.cardId))
+                        piles
                 , activePile =
                     if AssocList.member dragState.dictKey piles then
                         Just dragState.dictKey

--- a/src/elm/Pile.elm
+++ b/src/elm/Pile.elm
@@ -39,10 +39,10 @@ emptyPile =
 
 
 addCard : ( Math.Vector2.Vec2, Html Msg ) -> CardPile -> CardPile
-addCard ( pos, cont ) ({ uid, idleCards } as pile) =
+addCard ( position, content ) ({ uid, idleCards } as pile) =
     { pile
         | uid = uid + 1
-        , idleCards = Card (String.fromInt uid) pos cont :: idleCards
+        , idleCards = Card (String.fromInt uid) position content :: idleCards
     }
 
 
@@ -111,24 +111,24 @@ init prePiles =
                     xs =
                         List.range 0 (List.length cardsContent)
                             |> List.map
-                                (\n ->
-                                    if modBy 2 n == 0 then
-                                        n * 120
+                                (\number ->
+                                    if modBy 2 number == 0 then
+                                        number * 120
 
                                     else
-                                        n * 85
+                                        number * 85
                                 )
                             |> List.map toFloat
 
                     ys =
                         List.range 0 (List.length cardsContent)
                             |> List.map
-                                (\n ->
-                                    if modBy 2 n == 0 then
-                                        n * 60
+                                (\number ->
+                                    if modBy 2 number == 0 then
+                                        number * 60
 
                                     else
-                                        n * 75
+                                        number * 75
                                 )
                             |> List.map toFloat
                 in

--- a/src/elm/Pile.elm
+++ b/src/elm/Pile.elm
@@ -7,7 +7,7 @@ import Draggable.Events
 import Html exposing (Html)
 import Html.Attributes
 import Html.Events
-import Math.Vector2 exposing (Vec2)
+import Math.Vector2
 
 
 type alias Id =
@@ -16,12 +16,12 @@ type alias Id =
 
 type alias Card =
     { id : Id
-    , position : Vec2
+    , position : Math.Vector2.Vec2
     , cont : Html Msg
     }
 
 
-dragCardBy : Vec2 -> Card -> Card
+dragCardBy : Math.Vector2.Vec2 -> Card -> Card
 dragCardBy delta card =
     { card | position = card.position |> Math.Vector2.add delta }
 
@@ -38,7 +38,7 @@ emptyPile =
     CardPile 0 Nothing []
 
 
-addCard : ( Vec2, Html Msg ) -> CardPile -> CardPile
+addCard : ( Math.Vector2.Vec2, Html Msg ) -> CardPile -> CardPile
 addCard ( pos, cont ) ({ uid, idleCards } as pile) =
     { pile
         | uid = uid + 1
@@ -46,7 +46,7 @@ addCard ( pos, cont ) ({ uid, idleCards } as pile) =
     }
 
 
-makeCardPile : List ( Vec2, Html Msg ) -> CardPile
+makeCardPile : List ( Math.Vector2.Vec2, Html Msg ) -> CardPile
 makeCardPile elements =
     List.foldl addCard emptyPile elements
 
@@ -75,7 +75,7 @@ stopDragging pack =
     { pack | idleCards = allCards pack, activeCard = Nothing }
 
 
-dragActiveBy : Vec2 -> CardPile -> CardPile
+dragActiveBy : Math.Vector2.Vec2 -> CardPile -> CardPile
 dragActiveBy delta ({ activeCard } as pack) =
     { pack | activeCard = activeCard |> Maybe.map (dragCardBy delta) }
 
@@ -95,7 +95,7 @@ type alias DragState =
 
 type Msg
     = DragMsg (Draggable.Msg DragState)
-    | OnDragBy Vec2
+    | OnDragBy Math.Vector2.Vec2
     | StartDragging DragState
     | StopDragging
 

--- a/src/elm/Pile.elm
+++ b/src/elm/Pile.elm
@@ -1,0 +1,190 @@
+module Pile exposing (..)
+
+import Draggable
+import Draggable.Events
+import Html exposing (Html)
+import Html.Attributes
+import Html.Events
+import Math.Vector2 exposing (Vec2)
+
+
+type alias Id =
+    String
+
+
+type alias Card =
+    { id : Id
+    , position : Vec2
+    , cont : Html Msg
+    }
+
+
+dragCardBy : Vec2 -> Card -> Card
+dragCardBy delta card =
+    { card | position = card.position |> Math.Vector2.add delta }
+
+
+type alias CardPile =
+    { uid : Int
+    , activeCard : Maybe Card
+    , idleCards : List Card
+    }
+
+
+emptyPile : CardPile
+emptyPile =
+    CardPile 0 Nothing []
+
+
+addCard : ( Vec2, Html Msg ) -> CardPile -> CardPile
+addCard ( pos, cont ) ({ uid, idleCards } as pile) =
+    { pile
+        | uid = uid + 1
+        , idleCards = Card (String.fromInt uid) pos cont :: idleCards
+    }
+
+
+makeCardPile : List ( Vec2, Html Msg ) -> CardPile
+makeCardPile elements =
+    List.foldl addCard emptyPile elements
+
+
+allCards : CardPile -> List Card
+allCards { activeCard, idleCards } =
+    activeCard
+        |> Maybe.map (\c -> c :: idleCards)
+        |> Maybe.withDefault idleCards
+
+
+startDragging : Id -> CardPile -> CardPile
+startDragging id pack =
+    let
+        ( targetAsList, others ) =
+            List.partition (.id >> (==) id) (allCards pack)
+    in
+    { pack
+        | idleCards = others
+        , activeCard = targetAsList |> List.head
+    }
+
+
+stopDragging : CardPile -> CardPile
+stopDragging pack =
+    { pack | idleCards = allCards pack, activeCard = Nothing }
+
+
+dragActiveBy : Vec2 -> CardPile -> CardPile
+dragActiveBy delta ({ activeCard } as pack) =
+    { pack | activeCard = activeCard |> Maybe.map (dragCardBy delta) }
+
+
+type alias Model =
+    { pile : CardPile
+    , drag : Draggable.State Id
+    }
+
+
+type Msg
+    = DragMsg (Draggable.Msg Id)
+    | OnDragBy Vec2
+    | StartDragging Id
+    | StopDragging
+
+
+init : List (Html Msg) -> Model
+init cardsContent =
+    -- will probably either radomly generate these vectors within bounds or
+    -- have some hand crafted numbers for initial layout
+    let
+        xs =
+            List.range 0 (List.length cardsContent)
+                |> List.map
+                    (\n ->
+                        if modBy 2 n == 0 then
+                            n * 120
+
+                        else
+                            n * 85
+                    )
+                |> List.map toFloat
+
+        ys =
+            List.range 0 (List.length cardsContent)
+                |> List.map
+                    (\n ->
+                        if modBy 2 n == 0 then
+                            n * 60
+
+                        else
+                            n * 75
+                    )
+                |> List.map toFloat
+    in
+    cardsContent
+        |> List.map3 (\x y cont -> ( Math.Vector2.vec2 x y, cont )) xs ys
+        |> makeCardPile
+        |> (\pile -> Model pile Draggable.init)
+
+
+
+-- These functions require wrapping in the programs main Msg type
+-- in order to be compatible
+
+
+dragConfig : (Msg -> msg) -> Draggable.Config Id msg
+dragConfig mainMsg =
+    Draggable.customConfig
+        [ Draggable.Events.onDragBy (\( dx, dy ) -> Math.Vector2.vec2 dx dy |> OnDragBy |> mainMsg)
+        , Draggable.Events.onDragStart (\a -> a |> StartDragging |> mainMsg)
+        ]
+
+
+update : (Msg -> msg) -> Msg -> Model -> ( Model, Cmd msg )
+update mainMsg msg ({ pile } as model) =
+    case msg of
+        OnDragBy delta ->
+            ( { model | pile = pile |> dragActiveBy delta }, Cmd.none )
+
+        StartDragging id ->
+            ( { model | pile = pile |> startDragging id }, Cmd.none )
+
+        StopDragging ->
+            ( { model | pile = pile |> stopDragging }, Cmd.none )
+
+        DragMsg dragMsg ->
+            Draggable.update (dragConfig mainMsg) dragMsg model
+
+
+subscriptions : (Msg -> msg) -> Model -> Sub msg
+subscriptions mainMsg { drag } =
+    Draggable.subscriptions DragMsg drag
+        |> Sub.map mainMsg
+
+
+cardView : Card -> Html Msg
+cardView { id, position, cont } =
+    let
+        x =
+            String.fromFloat (Math.Vector2.getX position) ++ "px"
+
+        y =
+            String.fromFloat (Math.Vector2.getY position) ++ "px"
+    in
+    Html.div
+        [ Html.Attributes.class "card"
+        , Html.Attributes.style "left" x
+        , Html.Attributes.style "top" y
+        , Html.Attributes.style "cursor" "move"
+        , Draggable.mouseTrigger id DragMsg
+        , Html.Events.onMouseUp StopDragging
+        ]
+        [ cont ]
+
+
+view : CardPile -> Html Msg
+view pile =
+    pile
+        |> allCards
+        |> List.map cardView
+        |> List.reverse
+        |> Html.div [ Html.Attributes.class "pile" ]

--- a/src/elm/Pile.elm
+++ b/src/elm/Pile.elm
@@ -62,7 +62,7 @@ startDragging : Id -> CardPile -> CardPile
 startDragging id pile =
     let
         ( targetAsList, others ) =
-            List.partition (.id >> (==) id) pile.idleCards
+            List.partition (\card -> card.id == id) pile.idleCards
     in
     { pile
         | idleCards = others

--- a/src/elm/View/Pile.elm
+++ b/src/elm/View/Pile.elm
@@ -1,0 +1,29 @@
+module View.Pile exposing (..)
+
+import Data
+import Html
+import Html.Attributes
+import Pile
+import View.Posts
+
+
+view : Pile.Data -> Html.Html msg
+view data =
+    case data of
+        Pile.Post post ->
+            Html.div [] (View.Posts.viewPost post False)
+
+        Pile.Image image ->
+            viewImage image
+
+
+viewImage : Data.Image -> Html.Html msg
+viewImage image =
+    Html.div
+        [ Html.Attributes.class "image-constraint" ]
+        [ Html.img
+            [ Html.Attributes.src image.source
+            , Html.Attributes.alt image.alt
+            ]
+            []
+        ]

--- a/src/elm/View/Pile.elm
+++ b/src/elm/View/Pile.elm
@@ -13,25 +13,6 @@ view data =
         Pile.Post post ->
             View.Posts.viewPostDraggable post
 
-        -- Html.div [] (View.Posts.viewPost post False)
-        -- Html.div [ Html.Attributes.class "post-draggable" ]
-        --     [ Html.h4 [ Html.Attributes.class "post-forwarded-from" ] [ Html.text (t ForwardedLabel ++ post.forwardedFrom) ]
-        --     , Html.img
-        --         [ Html.Attributes.class "post-avatar-draggable"
-        --         , Html.Attributes.src post.avatarSrc
-        --         ]
-        --     , Html.div [ Html.Attributes.class "post-content-draggable" ]
-        --         (View.Posts.viewVideo post.maybeVideo :: Markdown.markdownToHtml post.body)
-        --     , Html.div [ Html.Attributes.class "post-meta-info" ]
-        --         [ case post.maybeViewCount of
-        --             Just aViewCount ->
-        --                 Html.span [ Html.Attributes.class "post-view-count" ] [ viewPostViewCount aViewCount ]
-        --             Nothing ->
-        --                 Html.text ""
-        --         , Html.span [ Html.Attributes.class "post-time" ] [ viewPostTime post.datetime ]
-        --         ]
-        --         []
-        --     ]
         Pile.Image image ->
             viewImage image
 

--- a/src/elm/View/Pile.elm
+++ b/src/elm/View/Pile.elm
@@ -11,8 +11,27 @@ view : Pile.Data -> Html.Html msg
 view data =
     case data of
         Pile.Post post ->
-            Html.div [] (View.Posts.viewPost post False)
+            View.Posts.viewPostDraggable post
 
+        -- Html.div [] (View.Posts.viewPost post False)
+        -- Html.div [ Html.Attributes.class "post-draggable" ]
+        --     [ Html.h4 [ Html.Attributes.class "post-forwarded-from" ] [ Html.text (t ForwardedLabel ++ post.forwardedFrom) ]
+        --     , Html.img
+        --         [ Html.Attributes.class "post-avatar-draggable"
+        --         , Html.Attributes.src post.avatarSrc
+        --         ]
+        --     , Html.div [ Html.Attributes.class "post-content-draggable" ]
+        --         (View.Posts.viewVideo post.maybeVideo :: Markdown.markdownToHtml post.body)
+        --     , Html.div [ Html.Attributes.class "post-meta-info" ]
+        --         [ case post.maybeViewCount of
+        --             Just aViewCount ->
+        --                 Html.span [ Html.Attributes.class "post-view-count" ] [ viewPostViewCount aViewCount ]
+        --             Nothing ->
+        --                 Html.text ""
+        --         , Html.span [ Html.Attributes.class "post-time" ] [ viewPostTime post.datetime ]
+        --         ]
+        --         []
+        --     ]
         Pile.Image image ->
             viewImage image
 

--- a/src/elm/View/Posts.elm
+++ b/src/elm/View/Posts.elm
@@ -98,7 +98,10 @@ viewPost post isFirst =
 viewPostDraggable : Data.Post -> Html.Html msg
 viewPostDraggable post =
     Html.div [ Html.Attributes.class "post-draggable" ]
-        [ Html.h4 [ Html.Attributes.class "post-forwarded-from-draggable" ] [ Html.div [ Html.Attributes.class "post-forwarded-from" ] [ Html.text (t ForwardedLabel ++ post.forwardedFrom) ] ]
+        [ Html.h4 [ Html.Attributes.class "post-forwarded-from-draggable" ]
+            [ Html.div [ Html.Attributes.class "post-forwarded-from" ]
+                [ Html.text (t ForwardedLabel ++ post.forwardedFrom) ]
+            ]
         , Html.img
             [ Html.Attributes.class "post-avatar-draggable"
             , Html.Attributes.src post.avatarSrc
@@ -108,10 +111,14 @@ viewPostDraggable post =
             (viewVideo post.maybeVideo :: Markdown.markdownToHtml post.body)
         , Html.div [ Html.Attributes.class "post-meta-draggable" ]
             [ Html.span [ Html.Attributes.class "post-date-time-draggable" ]
-                [ Html.span [] [ viewPostDate post.datetime ], Html.span [] [ viewPostTime post.datetime ] ]
+                [ Html.span [] [ viewPostDate post.datetime ]
+                , Html.span [] [ viewPostTime post.datetime ]
+                ]
             , case post.maybeViewCount of
                 Just aViewCount ->
-                    Html.span [ Html.Attributes.class "post-view-count-draggable" ] [ viewPostViewCount aViewCount ]
+                    Html.span
+                        [ Html.Attributes.class "post-view-count-draggable" ]
+                        [ viewPostViewCount aViewCount ]
 
                 Nothing ->
                     Html.text ""

--- a/src/elm/View/Posts.elm
+++ b/src/elm/View/Posts.elm
@@ -1,4 +1,4 @@
-module View.Posts exposing (posts, view)
+module View.Posts exposing (view, viewPost)
 
 import Copy.Keys exposing (Key(..))
 import Copy.Text exposing (t)

--- a/src/elm/View/Posts.elm
+++ b/src/elm/View/Posts.elm
@@ -1,4 +1,4 @@
-module View.Posts exposing (view)
+module View.Posts exposing (posts, view)
 
 import Copy.Keys exposing (Key(..))
 import Copy.Text exposing (t)
@@ -10,7 +10,7 @@ import Msg exposing (Msg)
 import Time
 
 
-view : Data.SectionId -> List Data.Post -> Html.Html Msg
+view : Data.SectionId -> List Data.Post -> Html.Html msg
 view sectionId postList =
     if List.length postList > 0 then
         Html.div [ Html.Attributes.class "posts" ]
@@ -25,6 +25,21 @@ view sectionId postList =
 
     else
         Html.text ""
+
+
+posts : Data.SectionId -> List Data.Post -> List (Html.Html msg)
+posts sectionId postList =
+    if List.length postList > 0 then
+        List.map
+            (\post ->
+                viewPost post
+                    (isFirstOnDate post postList)
+            )
+            (Data.filterBySection sectionId postList)
+            |> List.concat
+
+    else
+        []
 
 
 isFirstOnDate : Data.Post -> List Data.Post -> Bool
@@ -47,7 +62,7 @@ isFirstOnDate post allPosts =
             False
 
 
-viewPost : Data.Post -> Bool -> List (Html.Html Msg)
+viewPost : Data.Post -> Bool -> List (Html.Html msg)
 viewPost post isFirst =
     [ Html.div [ Html.Attributes.class "post" ]
         [ if isFirst then
@@ -80,7 +95,7 @@ viewPost post isFirst =
     ]
 
 
-viewPostDate : Time.Posix -> Html.Html Msg
+viewPostDate : Time.Posix -> Html.Html msg
 viewPostDate posix =
     Html.text
         (String.join ""
@@ -93,7 +108,7 @@ viewPostDate posix =
         )
 
 
-viewPostTime : Time.Posix -> Html.Html Msg
+viewPostTime : Time.Posix -> Html.Html msg
 viewPostTime posix =
     Html.text
         ([ String.fromInt (Time.toHour Time.utc posix)
@@ -104,7 +119,7 @@ viewPostTime posix =
         )
 
 
-viewPostViewCount : Int -> Html.Html Msg
+viewPostViewCount : Int -> Html.Html msg
 viewPostViewCount viewCount =
     Html.text
         (if toFloat viewCount / 1000 > 1 then
@@ -115,7 +130,7 @@ viewPostViewCount viewCount =
         )
 
 
-viewVideo : Maybe String -> Html.Html Msg
+viewVideo : Maybe String -> Html.Html msg
 viewVideo videoSrc =
     case videoSrc of
         Just aVideoSrc ->

--- a/src/elm/View/Posts.elm
+++ b/src/elm/View/Posts.elm
@@ -1,4 +1,4 @@
-module View.Posts exposing (view, viewPost)
+module View.Posts exposing (view, viewPostDraggable)
 
 import Copy.Keys exposing (Key(..))
 import Copy.Text exposing (t)
@@ -93,6 +93,30 @@ viewPost post isFirst =
             []
         ]
     ]
+
+
+viewPostDraggable : Data.Post -> Html.Html msg
+viewPostDraggable post =
+    Html.div [ Html.Attributes.class "post-draggable" ]
+        [ Html.h4 [ Html.Attributes.class "post-forwarded-from-draggable" ] [ Html.div [ Html.Attributes.class "post-forwarded-from" ] [ Html.text (t ForwardedLabel ++ post.forwardedFrom) ] ]
+        , Html.img
+            [ Html.Attributes.class "post-avatar-draggable"
+            , Html.Attributes.src post.avatarSrc
+            ]
+            []
+        , Html.div [ Html.Attributes.class "post-content-draggable" ]
+            (viewVideo post.maybeVideo :: Markdown.markdownToHtml post.body)
+        , Html.div [ Html.Attributes.class "post-meta-draggable" ]
+            [ Html.span [ Html.Attributes.class "post-date-time-draggable" ]
+                [ Html.span [] [ viewPostDate post.datetime ], Html.span [] [ viewPostTime post.datetime ] ]
+            , case post.maybeViewCount of
+                Just aViewCount ->
+                    Html.span [ Html.Attributes.class "post-view-count-draggable" ] [ viewPostViewCount aViewCount ]
+
+                Nothing ->
+                    Html.text ""
+            ]
+        ]
 
 
 viewPostDate : Time.Posix -> Html.Html msg

--- a/src/elm/View/Section1.elm
+++ b/src/elm/View/Section1.elm
@@ -12,6 +12,9 @@ import View.Posts
 view : Model -> List (Html.Html Msg)
 view model =
     [ View.MainText.viewTop Data.Section1 model.content.mainText
-    , Pile.view model.pile1.pile |> Html.map Pile1
-    , View.Posts.view Data.Section1 model.content.posts
+    , if Tuple.second model.viewportHeightWidth < 800 then
+        View.Posts.view Data.Section1 model.content.posts
+
+      else
+        Pile.view model.pile1.pile |> Html.map Pile1
     ]

--- a/src/elm/View/Section1.elm
+++ b/src/elm/View/Section1.elm
@@ -3,7 +3,8 @@ module View.Section1 exposing (view)
 import Data
 import Html
 import Model exposing (Model)
-import Msg exposing (Msg)
+import Msg exposing (Msg(..))
+import Pile
 import View.MainText
 import View.Posts
 
@@ -11,5 +12,6 @@ import View.Posts
 view : Model -> List (Html.Html Msg)
 view model =
     [ View.MainText.viewTop Data.Section1 model.content.mainText
+    , Pile.view model.pile1.pile |> Html.map Pile1
     , View.Posts.view Data.Section1 model.content.posts
     ]

--- a/src/elm/View/Section1.elm
+++ b/src/elm/View/Section1.elm
@@ -16,5 +16,5 @@ view model =
         View.Posts.view Data.Section1 model.content.posts
 
       else
-        Pile.view model.pile1.pile |> Html.map Pile1
+        Pile.view Data.Section1 model.piles |> Html.map Piles
     ]

--- a/src/elm/View/Section1.elm
+++ b/src/elm/View/Section1.elm
@@ -6,6 +6,7 @@ import Model exposing (Model)
 import Msg exposing (Msg(..))
 import Pile
 import View.MainText
+import View.Pile
 import View.Posts
 
 
@@ -16,5 +17,5 @@ view model =
         View.Posts.view Data.Section1 model.content.posts
 
       else
-        Pile.view Data.Section1 model.piles |> Html.map Piles
+        Pile.view Data.Section1 View.Pile.view model.piles |> Html.map Piles
     ]

--- a/src/elm/View/Section10.elm
+++ b/src/elm/View/Section10.elm
@@ -3,11 +3,16 @@ module View.Section10 exposing (view)
 import Data
 import Html
 import Model exposing (Model)
-import Msg exposing (Msg)
+import Msg exposing (Msg(..))
+import Pile
 import View.Posts
 
 
 view : Model -> List (Html.Html Msg)
 view model =
-    [ View.Posts.view Data.Section10 model.content.posts
+    [ if Tuple.second model.viewportHeightWidth < 800 then
+        View.Posts.view Data.Section10 model.content.posts
+
+      else
+        Pile.view model.pile3.pile |> Html.map Pile3
     ]

--- a/src/elm/View/Section10.elm
+++ b/src/elm/View/Section10.elm
@@ -5,6 +5,7 @@ import Html
 import Model exposing (Model)
 import Msg exposing (Msg(..))
 import Pile
+import View.Pile
 import View.Posts
 
 
@@ -14,5 +15,5 @@ view model =
         View.Posts.view Data.Section10 model.content.posts
 
       else
-        Pile.view Data.Section10 model.piles |> Html.map Piles
+        Pile.view Data.Section10 View.Pile.view model.piles |> Html.map Piles
     ]

--- a/src/elm/View/Section10.elm
+++ b/src/elm/View/Section10.elm
@@ -14,5 +14,5 @@ view model =
         View.Posts.view Data.Section10 model.content.posts
 
       else
-        Pile.view model.pile3.pile |> Html.map Pile3
+        Pile.view Data.Section10 model.piles |> Html.map Piles
     ]

--- a/src/elm/View/Section4.elm
+++ b/src/elm/View/Section4.elm
@@ -16,5 +16,5 @@ view model =
         View.StackingImage.viewImageListStatic Data.Section4 model.content.images
 
       else
-        Pile.view model.pile2.pile |> Html.map Pile2
+        Pile.view Data.Section4 model.piles |> Html.map Piles
     ]

--- a/src/elm/View/Section4.elm
+++ b/src/elm/View/Section4.elm
@@ -6,6 +6,7 @@ import Model exposing (Model)
 import Msg exposing (Msg(..))
 import Pile
 import View.MainText
+import View.Pile
 import View.StackingImage
 
 
@@ -16,5 +17,5 @@ view model =
         View.StackingImage.viewImageListStatic Data.Section4 model.content.images
 
       else
-        Pile.view Data.Section4 model.piles |> Html.map Piles
+        Pile.view Data.Section4 View.Pile.view model.piles |> Html.map Piles
     ]

--- a/src/elm/View/Section4.elm
+++ b/src/elm/View/Section4.elm
@@ -3,7 +3,8 @@ module View.Section4 exposing (view)
 import Data
 import Html
 import Model exposing (Model)
-import Msg exposing (Msg)
+import Msg exposing (Msg(..))
+import Pile
 import View.MainText
 import View.StackingImage
 
@@ -11,5 +12,9 @@ import View.StackingImage
 view : Model -> List (Html.Html Msg)
 view model =
     [ View.MainText.viewTop Data.Section4 model.content.mainText
-    , View.StackingImage.viewImageList Data.Section4 model
+    , if Tuple.second model.viewportHeightWidth < 800 then
+        View.StackingImage.viewImageListStatic Data.Section4 model.content.images
+
+      else
+        Pile.view model.pile2.pile |> Html.map Pile2
     ]

--- a/src/elm/View/StackingImage.elm
+++ b/src/elm/View/StackingImage.elm
@@ -1,4 +1,4 @@
-module View.StackingImage exposing (viewImageList)
+module View.StackingImage exposing (viewImageList, viewImageListDraggable, viewImageListStatic)
 
 import Data
 import Html
@@ -10,7 +10,7 @@ import Model exposing (Model)
 import Msg exposing (Msg)
 
 
-viewImageList : Data.SectionId -> Model -> Html.Html Msg
+viewImageList : Data.SectionId -> Model -> Html.Html msg
 viewImageList section model =
     if List.length model.content.images > 0 then
         Html.div
@@ -25,7 +25,7 @@ viewImageList section model =
         Html.text ""
 
 
-viewImage : Float -> InView.State -> Data.Image -> Html.Html Msg
+viewImage : Float -> InView.State -> Data.Image -> Html.Html msg
 viewImage viewportHeight inViewState image =
     Html.div
         [ Html.Attributes.class "image" ]
@@ -34,6 +34,56 @@ viewImage viewportHeight inViewState image =
             , Html.Attributes.alt image.alt
             , Html.Attributes.style "z-index" (String.fromInt image.displayPosition)
             , Html.Attributes.style "max-height" (imageHeightFromViewport viewportHeight)
+            ]
+            []
+        ]
+
+
+viewImageListDraggable : Data.SectionId -> List Data.Image -> List (Html.Html msg)
+viewImageListDraggable section images =
+    if List.length images > 0 then
+        List.map
+            (\image -> viewImageDraggable image)
+            (Data.filterBySection section images)
+
+    else
+        []
+
+
+viewImageDraggable : Data.Image -> Html.Html msg
+viewImageDraggable image =
+    Html.div
+        [ Html.Attributes.class "image-constraint" ]
+        [ Html.img
+            [ Html.Attributes.src image.source
+            , Html.Attributes.alt image.alt
+            ]
+            []
+        ]
+
+
+viewImageListStatic : Data.SectionId -> List Data.Image -> Html.Html msg
+viewImageListStatic section images =
+    if List.length images > 0 then
+        Html.div
+            [ Html.Attributes.class "images-mobile"
+            ]
+            (List.map
+                (\image -> viewImageStatic image)
+                (Data.filterBySection section images)
+            )
+
+    else
+        Html.text ""
+
+
+viewImageStatic : Data.Image -> Html.Html msg
+viewImageStatic image =
+    Html.div
+        []
+        [ Html.img
+            [ Html.Attributes.src image.source
+            , Html.Attributes.alt image.alt
             ]
             []
         ]


### PR DESCRIPTION
Fixes #209

## Notes / questions

- feels like it needs something to separate it out as a section from the other content, maybe just more padding?
- Still needs constraining in to stop things exiting the draggable area. though I think there's a question about wether to allow some overshoot so there's more screen space to play with. The posts feel very crowded on my screen which is reasonably large (but must be much smaller than the mock up)
- perfect constraint may on the right / bottom edge may take more time than we have as it would mean reading the boundingRect which is a pain in Elm and I'm not sure if this library will let me pass those details in when dragging. (thought it may do and it is possible to use the Hayleigh Hack™ to get those dimensions)
- Suprise edgecase of the element resizing when hitting the right edge
- bit off CSS refactoring needed to remove main padding round whole site encroaching on usable area
- feels a bit wrong to be storing html in the model but seemed like the simplest solution for handling different content types, alternative might be to pass in an `a -> Html msg`  function to `Draggable.view`
- posts need a bit of a refacter per design
- should probably pull my Draggable view code out of StackingImage etc but that's house keeping that can be done when other issues are sorted. 
