### PR TITLE
239 convert to draggable piles

### DIFF
--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -82,9 +82,17 @@ init flags =
         section4draggableContent =
             ( Data.Section4, content.images |> Data.filterBySection Data.Section4 |> List.map Pile.Image )
 
+        section8draggableContent : ( Data.SectionId, List Pile.Data )
+        section8draggableContent =
+            ( Data.Section8, content.images |> Data.filterBySection Data.Section8 |> List.map Pile.Image )
+
         section10draggableContent : ( Data.SectionId, List Pile.Data )
         section10draggableContent =
             ( Data.Section10, content.posts |> Data.filterBySection Data.Section10 |> List.map Pile.Post )
+
+        section16draggableContent : ( Data.SectionId, List Pile.Data )
+        section16draggableContent =
+            ( Data.Section16, content.posts |> Data.filterBySection Data.Section16 |> List.map Pile.Post )
     in
     ( { time = Time.millisToPosix 0
       , content = content
@@ -95,7 +103,14 @@ init flags =
       , viewportHeightWidth = ( 800, 800 )
       , chartHovering = []
       , terminalState = { input = "", history = [] }
-      , piles = Pile.init [ section1draggableContent, section4draggableContent, section10draggableContent ]
+      , piles =
+            Pile.init
+                [ section1draggableContent
+                , section4draggableContent
+                , section8draggableContent
+                , section10draggableContent
+                , section16draggableContent
+                ]
       }
     , Cmd.batch
         [ Random.generate NewRandomIntList generateRandomIntList

--- a/src/elm/Pile.elm
+++ b/src/elm/Pile.elm
@@ -105,6 +105,13 @@ type Msg
     | StopDragging
 
 
+clamp : { minVal : Int, maxVal : Int } -> Int -> Int
+clamp { minVal, maxVal } value =
+    value
+        |> min maxVal
+        |> max minVal
+
+
 init : List ( Data.SectionId, List Data ) -> Model
 init prePiles =
     -- will probably either radomly generate these vectors within bounds or
@@ -113,6 +120,12 @@ init prePiles =
         |> List.map
             (\( key, cardsContent ) ->
                 let
+                    clampX =
+                        clamp { minVal = 0, maxVal = 800 }
+
+                    clampY =
+                        clamp { minVal = 0, maxVal = 800 }
+
                     xs =
                         List.range 0 (List.length cardsContent)
                             |> List.map
@@ -123,6 +136,7 @@ init prePiles =
                                     else
                                         number * 85
                                 )
+                            |> List.map clampX
                             |> List.map toFloat
 
                     ys =
@@ -135,6 +149,7 @@ init prePiles =
                                     else
                                         number * 75
                                 )
+                            |> List.map clampY
                             |> List.map toFloat
                 in
                 cardsContent

--- a/src/elm/View/Section16.elm
+++ b/src/elm/View/Section16.elm
@@ -6,8 +6,10 @@ import Data
 import Html
 import Model exposing (Model)
 import Msg exposing (Msg)
+import Pile
 import View.MainText
 import View.Messages
+import View.Pile
 import View.Posts
 
 
@@ -15,5 +17,9 @@ view : Model -> List (Html.Html Msg)
 view model =
     [ View.MainText.viewTop Data.Section16 model.content.mainText
     , View.Messages.view model.inView Data.Section16 model.content.messages (t Section16MessageHeading) Nothing
-    , View.Posts.view Data.Section16 model.content.posts
+    , if Tuple.second model.viewportHeightWidth < 800 then
+        View.Posts.view Data.Section16 model.content.posts
+
+      else
+        Pile.view Data.Section16 View.Pile.view model.piles |> Html.map Msg.Piles
     ]

--- a/src/elm/View/Section8.elm
+++ b/src/elm/View/Section8.elm
@@ -4,12 +4,18 @@ import Data
 import Html
 import Model exposing (Model)
 import Msg exposing (Msg)
+import Pile
 import View.MainText
+import View.Pile
 import View.StackingImage
 
 
 view : Model -> List (Html.Html Msg)
 view model =
-    [ View.MainText.viewTop Data.Section4 model.content.mainText
-    , View.StackingImage.viewImageList Data.Section4 model
+    [ View.MainText.viewTop Data.Section8 model.content.mainText
+    , if Tuple.second model.viewportHeightWidth < 800 then
+        View.StackingImage.viewImageListStatic Data.Section8 model.content.images
+
+      else
+        Pile.view Data.Section8 View.Pile.view model.piles |> Html.map Msg.Piles
     ]


### PR DESCRIPTION
Fixes #239 

## Description

- section 8 and 16 are now draggable
- I tested section 8 by adding in a bit of content locally, it will need real content adding as I removed the link to section 4 content
- section 16 had many posts so I added a clamp function around the card positions based on our initial viewport defaults, this could either be tweaked by adjusting the default values or we could look into using real values from the screen when they arrive. probably a future ticket though.
