### PR TITLE
prevent loss of content on smaller screens

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -367,6 +367,16 @@ p {
   margin-left: 30%;
 }
 
+@media (max-width: 800px) {
+  .left .message {
+    margin-right: 10%;
+  }
+
+  .right .message {
+    margin-left: 10%;
+  }
+}
+
 .left .message .message-body {
   background-color: var(--black);
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -590,6 +590,14 @@ p {
   height: 0;
 }
 
+@media (max-width: 800px) {
+  .tickers {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+  }
+}
+
 .ticker {
   background-color: var(--black);
   color: var(--white);

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -41,6 +41,13 @@ p {
   width: 100%;
 }
 
+@media (max-width: 800px) {
+  .section {
+    padding: 4.5rem 10px;
+    width: 100%;
+  }
+}
+
 #section-one {
   padding-top: 0;
 }
@@ -115,6 +122,14 @@ p {
   text-align: left;
 }
 
+@media (max-width: 800px) {
+  .main-text {
+    padding: 10px 10px 10px 10px;
+    max-width: 600px;
+    margin-inline: auto;
+  }
+}
+
 .main-text-title {
   font-family: "TT Firs Neue Var Roman", Inter, Roboto, "Helvetica Neue",
     "Arial Nova", "Nimbus Sans", Arial, sans-serif;
@@ -129,51 +144,59 @@ p {
   padding-bottom: 40px;
 }
 
+@media (max-width: 800px) {
+  .main-text-body {
+    padding: 10px 10px 20px 10px;
+  }
+}
+
 .hand-drawn-border {
   border-image: url(/images/borders/border.svg) 10 10 10 10 stretch stretch;
   border-style: solid;
   border-width: 10px 10px 10px 10px;
 }
 
-#section-eight .hand-drawn-border,
-#section-eleven .hand-drawn-border,
-#section-fifteen .hand-drawn-border,
-#section-five .hand-drawn-border {
-  border-image: url(/images/borders/hand-drawn-border-1.svg) 25 25 50 25 stretch
-    stretch;
-  border-style: solid;
-  border-width: 25px 25px 50px 25px;
-}
+@media (min-width: 800px) {
+  #section-eight .hand-drawn-border,
+  #section-eleven .hand-drawn-border,
+  #section-fifteen .hand-drawn-border,
+  #section-five .hand-drawn-border {
+    border-image: url(/images/borders/hand-drawn-border-1.svg) 25 25 50 25
+      stretch stretch;
+    border-style: solid;
+    border-width: 25px 25px 50px 25px;
+  }
 
-#section-four .hand-drawn-border,
-#section-fourteen .hand-drawn-border,
-#section-nine .hand-drawn-border,
-#section-one .hand-drawn-border {
-  border-image: url(/images/borders/hand-drawn-border-2.svg) 25 25 50 25 stretch
-    stretch;
-  border-style: solid;
-  border-width: 25px 25px 50px 25px;
-}
+  #section-four .hand-drawn-border,
+  #section-fourteen .hand-drawn-border,
+  #section-nine .hand-drawn-border,
+  #section-one .hand-drawn-border {
+    border-image: url(/images/borders/hand-drawn-border-2.svg) 25 25 50 25
+      stretch stretch;
+    border-style: solid;
+    border-width: 25px 25px 50px 25px;
+  }
 
-#section-seven .hand-drawn-border,
-#section-seventeen .hand-drawn-border,
-#section-six .hand-drawn-border,
-#section-sixteen .hand-drawn-border {
-  border-image: url(/images/borders/hand-drawn-border-3.svg) 25 25 100 25
-    stretch stretch;
-  border-style: solid;
-  border-width: 25px 25px 100px 25px;
-}
+  #section-seven .hand-drawn-border,
+  #section-seventeen .hand-drawn-border,
+  #section-six .hand-drawn-border,
+  #section-sixteen .hand-drawn-border {
+    border-image: url(/images/borders/hand-drawn-border-3.svg) 25 25 100 25
+      stretch stretch;
+    border-style: solid;
+    border-width: 25px 25px 100px 25px;
+  }
 
-#section-ten .hand-drawn-border,
-#section-thirteen .hand-drawn-border,
-#section-three .hand-drawn-border,
-#section-twelve .hand-drawn-border,
-#section-two .hand-drawn-border {
-  border-image: url(/images/borders/hand-drawn-border-4.svg) 25 25 95 25 stretch
-    stretch;
-  border-style: solid;
-  border-width: 25px 25px 95px 25px;
+  #section-ten .hand-drawn-border,
+  #section-thirteen .hand-drawn-border,
+  #section-three .hand-drawn-border,
+  #section-twelve .hand-drawn-border,
+  #section-two .hand-drawn-border {
+    border-image: url(/images/borders/hand-drawn-border-4.svg) 25 25 95 25
+      stretch stretch;
+    border-style: solid;
+    border-width: 25px 25px 95px 25px;
+  }
 }
 
 /** Post **/

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -299,6 +299,7 @@ p {
   border: solid 1px var(--white);
   margin: 0 auto;
   max-width: 1040px;
+  word-wrap: break-word;
 }
 
 .messages a {

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -2,6 +2,7 @@ port module Main exposing (main)
 
 import Browser
 import Browser.Dom
+import Browser.Events
 import Copy.Keys exposing (Key(..))
 import Copy.Text exposing (t)
 import Data
@@ -112,6 +113,7 @@ subscriptions model =
         , InView.subscriptions InViewMsg model.inView
         , onScroll OnScroll
         , Pile.subscriptions model.piles |> Sub.map Piles
+        , Browser.Events.onResize (\newWidth newHeight -> OnResize ( toFloat newHeight, toFloat newHeight ))
         ]
 
 
@@ -156,6 +158,11 @@ update msg model =
 
         OnScroll offset ->
             ( { model | inView = InView.updateViewportOffset offset model.inView }
+            , Cmd.none
+            )
+
+        OnResize viewportHeightWidth ->
+            ( { model | viewportHeightWidth = viewportHeightWidth }
             , Cmd.none
             )
 

--- a/src/elm/Msg.elm
+++ b/src/elm/Msg.elm
@@ -13,6 +13,7 @@ type Msg
     | Tick Time.Posix
     | NewRandomIntList (List Int)
     | OnScroll { x : Float, y : Float }
+    | OnResize ( Float, Float )
     | InViewMsg InView.Msg
     | GotViewport Browser.Dom.Viewport
     | OnElementLoad String

--- a/src/elm/View/Section11.elm
+++ b/src/elm/View/Section11.elm
@@ -40,19 +40,33 @@ view model =
 
 viewTickers : Model -> Html.Html Msg
 viewTickers model =
-    Html.div [ Html.Attributes.class "tickers" ]
-        (List.map
-            (\ticker -> viewTicker model.viewportHeightWidth model.time ticker)
-            model.tickerState
-        )
+    if Tuple.second model.viewportHeightWidth < 800 then
+        Html.ul [ Html.Attributes.class "tickers", Html.Attributes.attribute "role" "list" ]
+            (List.map
+                (\ticker -> viewTicker model.viewportHeightWidth model.time ticker)
+                model.tickerState
+            )
+
+    else
+        Html.div [ Html.Attributes.class "tickers" ]
+            (List.map
+                (\ticker -> viewTicker model.viewportHeightWidth model.time ticker)
+                model.tickerState
+            )
 
 
 viewTicker : ( Float, Float ) -> Time.Posix -> Data.TickerState -> Html.Html Msg
 viewTicker viewportHeightWidth now tickerState =
-    Simple.Animation.Animated.div
-        (slideInTicker viewportHeightWidth tickerState.id)
-        [ Html.Attributes.class "ticker" ]
-        [ Html.h2 [] [ Html.text (tickerState.label ++ ": " ++ viewTickerCount now tickerState) ] ]
+    if Tuple.second viewportHeightWidth < 800 then
+        Html.li
+            [ Html.Attributes.class "ticker" ]
+            [ Html.div [] [ Html.text (tickerState.label ++ ": " ++ viewTickerCount now tickerState) ] ]
+
+    else
+        Simple.Animation.Animated.div
+            (slideInTicker viewportHeightWidth tickerState.id)
+            [ Html.Attributes.class "ticker" ]
+            [ Html.h2 [] [ Html.text (tickerState.label ++ ": " ++ viewTickerCount now tickerState) ] ]
 
 
 viewTickerCount : Time.Posix -> Data.TickerState -> String

--- a/src/elm/View/Section12.elm
+++ b/src/elm/View/Section12.elm
@@ -27,5 +27,8 @@ sectionHeightStringFromViewport ( height, _ ) =
 
 
 fontSizeStringFromViewport : ( Float, Float ) -> String
-fontSizeStringFromViewport ( _, width ) =
-    String.fromFloat (width / 18) ++ "px"
+fontSizeStringFromViewport ( height, width ) =
+    if width < 800 then
+        String.fromFloat (height / 24) ++ "px"
+    else
+        String.fromFloat (width / 18) ++ "px"


### PR DESCRIPTION
Fixes #241 

## Description

- Tighten up padding/margin on mobile.
- Use a less exaggerated hand drawn border for main text.
- Allow words to be broken at any point in the text chats.
- Show tickers as a list instead of floating elements.
- Some of the "wack a mole" inconsistencies we were noticing when on call were due to not updating the dimensions of the viewport after the initial page load. 