### PR TITLE
fix missing references

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -187,6 +187,21 @@ p {
   padding: 1rem 1.5rem;
 }
 
+.references {
+  padding-inline-start: 1rem;
+}
+
+.reference-link {
+  color: var(--white);
+  word-wrap: break-word;
+}
+
+.reference-link:hover {
+  background-color: var(--white);
+  color: var(--black);
+  text-decoration: none;
+}
+
 /** Main Text **/
 
 .main-texts {

--- a/src/elm/Data.elm
+++ b/src/elm/Data.elm
@@ -242,7 +242,7 @@ contextDecoder =
                 )
         )
         (Json.Decode.maybe (Json.Decode.field "fact-check" Json.Decode.string))
-        (Json.Decode.maybe (Json.Decode.field "references" (Json.Decode.list Json.Decode.string))
+        (Json.Decode.maybe (Json.Decode.field "references" (Json.Decode.list <| Json.Decode.field "reference" Json.Decode.string))
             |> Json.Decode.andThen emptyListFromMaybe
         )
 

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -21,6 +21,9 @@ import View
 port onScroll : ({ x : Float, y : Float } -> msg) -> Sub msg
 
 
+port onGrow : (Float -> msg) -> Sub msg
+
+
 main : Program Data.Flags Model Msg
 main =
     Browser.document
@@ -99,6 +102,7 @@ init flags =
       , content = content
       , tickerState = initialTickerState
       , breachCount = 0
+      , domHeight = 0.0
       , randomIntList = []
       , inView = inViewModel
       , viewportHeightWidth = ( 800, 800 )
@@ -127,6 +131,7 @@ subscriptions model =
         [ Time.every 100 Tick -- 10 times per second
         , InView.subscriptions InViewMsg model.inView
         , onScroll OnScroll
+        , onGrow OnGrow
         , Pile.subscriptions model.piles |> Sub.map Piles
         , Browser.Events.onResize (\newWidth newHeight -> OnResize ( toFloat newHeight, toFloat newWidth ))
         ]
@@ -175,6 +180,21 @@ update msg model =
             ( { model | inView = InView.updateViewportOffset offset model.inView }
             , Cmd.none
             )
+
+        OnGrow height ->
+            if model.domHeight == height then
+                ( model
+                , Cmd.none
+                )
+
+            else
+                let
+                    ( inView, inViewCmds ) =
+                        InView.addElements InViewMsg [] model.inView
+                in
+                ( { model | domHeight = height, inView = inView }
+                , inViewCmds
+                )
 
         OnResize viewportHeightWidth ->
             ( { model | viewportHeightWidth = viewportHeightWidth }

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -128,7 +128,7 @@ subscriptions model =
         , InView.subscriptions InViewMsg model.inView
         , onScroll OnScroll
         , Pile.subscriptions model.piles |> Sub.map Piles
-        , Browser.Events.onResize (\newWidth newHeight -> OnResize ( toFloat newHeight, toFloat newHeight ))
+        , Browser.Events.onResize (\newWidth newHeight -> OnResize ( toFloat newHeight, toFloat newWidth ))
         ]
 
 

--- a/src/elm/Model.elm
+++ b/src/elm/Model.elm
@@ -18,6 +18,7 @@ type alias Model =
     , chartHovering : List (Chart.Item.One Data.LineChartDatum Chart.Item.Dot)
     , terminalState : TerminalState
     , piles : Pile.Model
+    , domHeight : Float
     }
 
 

--- a/src/elm/Msg.elm
+++ b/src/elm/Msg.elm
@@ -13,6 +13,7 @@ type Msg
     | Tick Time.Posix
     | NewRandomIntList (List Int)
     | OnScroll { x : Float, y : Float }
+    | OnGrow Float
     | OnResize ( Float, Float )
     | InViewMsg InView.Msg
     | GotViewport Browser.Dom.Viewport

--- a/src/elm/View/Context.elm
+++ b/src/elm/View/Context.elm
@@ -106,10 +106,10 @@ viewReferences referenceList =
         , Html.dd
             [ Html.Attributes.class "context-content"
             ]
-            [ Html.ol []
+            [ Html.ol [ Html.Attributes.class "references" ]
                 (List.map
                     (\reference ->
-                        Html.li [] [ Html.text reference ]
+                        Html.li [] [ Html.a [ Html.Attributes.class "reference-link", Html.Attributes.href reference ] [ Html.text reference ] ]
                     )
                     referenceList
                 )

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -6,38 +6,38 @@ import "@fontsource/source-code-pro";
 
 import { Elm } from "../elm/Main.elm";
 
-import context from "../../data/context.json"
-import mainText from "../../data/main-text.json"
-import posts from "../../data/posts.json"
-import messages from "../../data/messages.json"
-import images from "../../data/images.json"
-import graphs from "../../data/graphs.json"
-import terminals from "../../data/terminals.json"
-import tickers from "../../data/tickers.json"
+import context from "../../data/context.json";
+import mainText from "../../data/main-text.json";
+import posts from "../../data/posts.json";
+import messages from "../../data/messages.json";
+import images from "../../data/images.json";
+import graphs from "../../data/graphs.json";
+import terminals from "../../data/terminals.json";
+import tickers from "../../data/tickers.json";
 
 if (process.env.NODE_ENV === "development") {
-    const ElmDebugTransform = await import("elm-debug-transformer");
+  const ElmDebugTransform = await import("elm-debug-transformer");
 
-    ElmDebugTransform.register({
-        simple_mode: true
-    });
+  ElmDebugTransform.register({
+    simple_mode: true,
+  });
 }
 
 const root = document.querySelector("#app div");
 const app = Elm.Main.init({
-    node: root,
-    flags: {
-        "context": context,
-        "main-text": mainText,
-        "posts": posts,
-        "messages": messages,
-        "images": images,
-        "graphs": graphs,
-        "terminals": terminals,
-        "tickers": tickers
-    }
+  node: root,
+  flags: {
+    context: context,
+    "main-text": mainText,
+    posts: posts,
+    messages: messages,
+    images: images,
+    graphs: graphs,
+    terminals: terminals,
+    tickers: tickers,
+  },
 });
 
 window.addEventListener("scroll", () => {
-    app.ports.onScroll.send({x: window.scrollX, y: window.scrollY});
+  app.ports.onScroll.send({ x: window.scrollX, y: window.scrollY });
 });

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -41,3 +41,9 @@ const app = Elm.Main.init({
 window.addEventListener("scroll", () => {
   app.ports.onScroll.send({ x: window.scrollX, y: window.scrollY });
 });
+
+const sizeObserver = new ResizeObserver((entries) => {
+  app.ports.onScroll.send(entries[0].borderBoxSize[0].blockSize);
+});
+
+sizeObserver.observe(document.body);


### PR DESCRIPTION
Fixes #247 

## Description

- the markdown to json created an array of objects not strings so a quick fix to unwrap that when decoding.
- All sections with content now showing (Sections  5,8,14 don't have any)
- Discovered another bug which has been fixed, the `inView` state was going out of sync further down the page as more elements loaded, the large grid of faces for the tickers is a likely culprit but subscribing to size changes via a port catches it whatever the issue is.

This does make me wonder if in the future it would be better to use [`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)
