### PR TITLE
255 graph tweaks

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -531,6 +531,11 @@ p {
   font-size: 0.75rem;
   margin: 4rem auto;
   max-width: 80%;
+
+.chart-legend {
+  display: flex;
+  flex-wrap: wrap;
+  width: 90%;
 }
 
 /** Faces with information **/

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -531,6 +531,9 @@ p {
   font-size: 0.75rem;
   margin: 4rem auto;
   max-width: 80%;
+  font-family: "TT Firs Neue Var Roman", Inter, Roboto, "Helvetica Neue",
+    "Arial Nova", "Nimbus Sans", Arial, sans-serif;
+}
 
 .chart-legend {
   display: flex;

--- a/src/elm/View/Graph.elm
+++ b/src/elm/View/Graph.elm
@@ -25,8 +25,8 @@ view model sectionId =
         [ Chart.Attributes.height 300
         , Chart.Attributes.width 600
         , Chart.Attributes.range
-            [ Chart.Attributes.lowest (dateRangeStart graph.dataPoints) Chart.Attributes.exactly
-            , Chart.Attributes.highest (dateRangeEnd graph.dataPoints) Chart.Attributes.exactly
+            [ Chart.Attributes.lowest (dateRangeStart sectionId graph.dataPoints) Chart.Attributes.exactly
+            , Chart.Attributes.highest (dateRangeEnd sectionId graph.dataPoints) Chart.Attributes.exactly
             ]
         , Chart.Attributes.domain
             [ Chart.Attributes.lowest (yValueLowest graph.dataPoints) Chart.Attributes.exactly
@@ -208,17 +208,65 @@ allDates dataPoints =
         |> List.sort
 
 
-dateRangeStart : List Data.LineChartDatum -> Float
-dateRangeStart dataPoints =
+dateRangeStart : Data.SectionId -> List Data.LineChartDatum -> Float
+dateRangeStart id dataPoints =
     List.head (allDates dataPoints)
         |> Maybe.withDefault (toFloat 883612800000)
+        |> floorDate id
 
 
-dateRangeEnd : List Data.LineChartDatum -> Float
-dateRangeEnd dataPoints =
+dateRangeEnd : Data.SectionId -> List Data.LineChartDatum -> Float
+dateRangeEnd id dataPoints =
     List.reverse (allDates dataPoints)
         |> List.head
         |> Maybe.withDefault (toFloat 1672531200000)
+        |> ceilingDate id
+
+
+oneYearInMiliseconds : Int
+oneYearInMiliseconds =
+    31556952000
+
+
+oneWeekInMiliseconds : Int
+oneWeekInMiliseconds =
+    604800000
+
+
+floorDate : Data.SectionId -> Float -> Float
+floorDate id milis =
+    let
+        unit =
+            if id == Data.Section3 then
+                oneWeekInMiliseconds
+
+            else
+                oneYearInMiliseconds
+    in
+    milis
+        |> floor
+        |> (\time -> time // unit)
+        |> (\units -> units * unit)
+        |> (\val -> val - unit)
+        |> toFloat
+
+
+ceilingDate : Data.SectionId -> Float -> Float
+ceilingDate id milis =
+    let
+        unit =
+            if id == Data.Section3 then
+                oneWeekInMiliseconds
+
+            else
+                oneYearInMiliseconds
+    in
+    milis
+        |> floor
+        |> (\time -> time // unit)
+        |> (\units -> units * unit)
+        |> (+) unit
+        |> toFloat
 
 
 allYValues : List Data.LineChartDatum -> List Float

--- a/src/elm/View/Graph.elm
+++ b/src/elm/View/Graph.elm
@@ -7,6 +7,7 @@ import Chart.Item
 import Chart.Svg
 import Data
 import Html
+import Html.Attributes
 import Model exposing (Model)
 import Msg exposing (Msg)
 import Svg
@@ -139,10 +140,10 @@ view model sectionId =
             graph.dataPoints
         , Chart.legendsAt .min
             .max
-            [ Chart.Attributes.row
-            , Chart.Attributes.moveRight 50
+            [ Chart.Attributes.moveRight 50
             , Chart.Attributes.spacing 15
             , Chart.Attributes.moveUp 25
+            , Chart.Attributes.htmlAttrs [ Html.Attributes.class "chart-legend" ]
             ]
             []
         , Chart.each model.chartHovering <|

--- a/src/elm/View/Graph.elm
+++ b/src/elm/View/Graph.elm
@@ -48,7 +48,7 @@ view model sectionId =
             [ Chart.Attributes.format (\yLabel -> viewYLabel sectionId (String.fromFloat yLabel))
             , Chart.Attributes.color "#FFFFFF"
             ]
-        , Chart.generate 20 (Chart.Svg.times Time.utc) .x [] <|
+        , Chart.generate 15 (Chart.Svg.times Time.utc) .x [] <|
             \_ info ->
                 [ Chart.xLabel
                     [ Chart.Attributes.x (toFloat <| Time.posixToMillis info.timestamp)

--- a/src/elm/View/Graph.elm
+++ b/src/elm/View/Graph.elm
@@ -21,170 +21,183 @@ view model sectionId =
         graph =
             List.head (Data.filterBySection sectionId model.content.graphs)
                 |> Maybe.withDefault Data.lineChartData
-    in
-    Chart.chart
-        [ Chart.Attributes.height 300
-        , Chart.Attributes.width 600
-        , Chart.Attributes.range
-            [ Chart.Attributes.lowest (dateRangeStart sectionId graph.dataPoints) Chart.Attributes.exactly
-            , Chart.Attributes.highest (dateRangeEnd sectionId graph.dataPoints) Chart.Attributes.exactly
-            ]
-        , Chart.Attributes.domain
-            [ Chart.Attributes.lowest (yValueLowest graph.dataPoints) Chart.Attributes.exactly
-            , Chart.Attributes.highest (yValueHighest graph.dataPoints) Chart.Attributes.exactly
-            ]
-        , Chart.Events.onMouseMove Msg.OnChartHover
-            (Chart.Events.getNearest Chart.Item.dots)
-        , Chart.Events.onMouseLeave (Msg.OnChartHover [])
-        ]
-        [ Chart.labelAt (Chart.Attributes.percent 50)
-            (Chart.Attributes.percent 115)
-            [ Chart.Attributes.fontSize 20
-            , Chart.Attributes.color "#FFFFFF"
-            ]
-            [ Svg.text graph.title ]
-        , Chart.xAxis [ Chart.Attributes.color "#FFFFFF" ]
-        , Chart.yAxis [ Chart.Attributes.color "#FFFFFF" ]
-        , Chart.yLabels
-            [ Chart.Attributes.format (\yLabel -> viewYLabel sectionId (String.fromFloat yLabel))
-            , Chart.Attributes.color "#FFFFFF"
-            ]
-        , Chart.generate 15 (Chart.Svg.times Time.utc) .x [] <|
-            \_ info ->
-                [ Chart.xLabel
-                    [ Chart.Attributes.x (toFloat <| Time.posixToMillis info.timestamp)
-                    , Chart.Attributes.withGrid
-                    , Chart.Attributes.color "#FFFFFF"
-                    ]
-                    [ Svg.text (formatFullTime Time.utc info.timestamp) ]
-                ]
-        , Chart.series .x
-            ([ Chart.interpolatedMaybe (\item -> item.y1.count)
-                [ Chart.Attributes.color "#E4003B" ]
-                [ Chart.Attributes.color "#E40038"
-                , Chart.Attributes.circle
-                , Chart.Attributes.size 4
-                ]
-                |> Chart.named (Maybe.withDefault "" graph.set1Label)
-             ]
-                ++ (case graph.set2Label of
-                        Just aLabel ->
-                            [ Chart.interpolatedMaybe (\item -> item.y2.count)
-                                [ Chart.Attributes.color "#0087DC" ]
-                                [ Chart.Attributes.color "#0087DC"
-                                , Chart.Attributes.circle
-                                , Chart.Attributes.size 4
-                                ]
-                                |> Chart.named aLabel
-                            ]
 
-                        Nothing ->
-                            []
-                   )
-                ++ (case graph.set3Label of
-                        Just aLabel ->
-                            [ Chart.interpolatedMaybe (\item -> item.y3.count)
-                                []
-                                [ Chart.Attributes.circle, Chart.Attributes.size 3 ]
-                                |> Chart.named aLabel
-                            ]
-
-                        Nothing ->
-                            []
-                   )
-                ++ (case graph.set4Label of
-                        Just aLabel ->
-                            [ Chart.interpolatedMaybe (\item -> item.y4.count)
-                                []
-                                [ Chart.Attributes.circle, Chart.Attributes.size 3 ]
-                                |> Chart.named aLabel
-                            ]
-
-                        Nothing ->
-                            []
-                   )
-                ++ (case graph.set5Label of
-                        Just aLabel ->
-                            [ Chart.interpolatedMaybe (\item -> item.y5.count)
-                                []
-                                [ Chart.Attributes.circle, Chart.Attributes.size 3 ]
-                                |> Chart.named aLabel
-                            ]
-
-                        Nothing ->
-                            []
-                   )
-                ++ (case graph.set6Label of
-                        Just aLabel ->
-                            [ Chart.interpolatedMaybe (\item -> item.y6.count)
-                                []
-                                [ Chart.Attributes.circle, Chart.Attributes.size 3 ]
-                                |> Chart.named aLabel
-                            ]
-
-                        Nothing ->
-                            []
-                   )
-                ++ (case graph.set7Label of
-                        Just aLabel ->
-                            [ Chart.interpolatedMaybe (\item -> item.y7.count)
-                                []
-                                [ Chart.Attributes.circle, Chart.Attributes.size 3 ]
-                                |> Chart.named aLabel
-                            ]
-
-                        Nothing ->
-                            []
-                   )
-            )
+        yAxisLabelPadding =
             graph.dataPoints
-        , Chart.legendsAt .min
-            .max
-            [ Chart.Attributes.moveRight 50
-            , Chart.Attributes.spacing 15
-            , Chart.Attributes.moveUp 25
-            , Chart.Attributes.htmlAttrs [ Html.Attributes.class "chart-legend" ]
+                |> yValueHighest
+                |> round
+                |> String.fromInt
+                |> viewYLabel sectionId
+                |> String.length
+                |> (+) 2
+                |> String.fromInt
+                |> (\width -> width ++ "ch")
+    in
+    Html.div [ Html.Attributes.class "chart", Html.Attributes.style "padding-left" yAxisLabelPadding ]
+        [ Chart.chart
+            [ Chart.Attributes.height 300
+            , Chart.Attributes.width 600
+            , Chart.Attributes.range
+                [ Chart.Attributes.lowest (dateRangeStart sectionId graph.dataPoints) Chart.Attributes.exactly
+                , Chart.Attributes.highest (dateRangeEnd sectionId graph.dataPoints) Chart.Attributes.exactly
+                ]
+            , Chart.Attributes.domain
+                [ Chart.Attributes.lowest (yValueLowest graph.dataPoints) Chart.Attributes.exactly
+                , Chart.Attributes.highest (yValueHighest graph.dataPoints) Chart.Attributes.exactly
+                ]
+            , Chart.Events.onMouseMove Msg.OnChartHover
+                (Chart.Events.getNearest Chart.Item.dots)
+            , Chart.Events.onMouseLeave (Msg.OnChartHover [])
             ]
-            []
-        , Chart.each model.chartHovering <|
-            \_ item ->
-                let
-                    data =
-                        Chart.Item.getData item
+            [ Chart.labelAt (Chart.Attributes.percent 50)
+                (Chart.Attributes.percent 115)
+                [ Chart.Attributes.fontSize 20
+                , Chart.Attributes.color "#FFFFFF"
+                ]
+                [ Svg.text graph.title ]
+            , Chart.xAxis [ Chart.Attributes.color "#FFFFFF" ]
+            , Chart.yAxis [ Chart.Attributes.color "#FFFFFF" ]
+            , Chart.yLabels
+                [ Chart.Attributes.format (\yLabel -> viewYLabel sectionId (String.fromFloat yLabel))
+                , Chart.Attributes.color "#FFFFFF"
+                ]
+            , Chart.generate 15 (Chart.Svg.times Time.utc) .x [] <|
+                \_ info ->
+                    [ Chart.xLabel
+                        [ Chart.Attributes.x (toFloat <| Time.posixToMillis info.timestamp)
+                        , Chart.Attributes.withGrid
+                        , Chart.Attributes.color "#FFFFFF"
+                        ]
+                        [ Svg.text (formatFullTime Time.utc info.timestamp) ]
+                    ]
+            , Chart.series .x
+                ([ Chart.interpolatedMaybe (\item -> item.y1.count)
+                    [ Chart.Attributes.color "#E4003B" ]
+                    [ Chart.Attributes.color "#E40038"
+                    , Chart.Attributes.circle
+                    , Chart.Attributes.size 4
+                    ]
+                    |> Chart.named (Maybe.withDefault "" graph.set1Label)
+                 ]
+                    ++ (case graph.set2Label of
+                            Just aLabel ->
+                                [ Chart.interpolatedMaybe (\item -> item.y2.count)
+                                    [ Chart.Attributes.color "#0087DC" ]
+                                    [ Chart.Attributes.color "#0087DC"
+                                    , Chart.Attributes.circle
+                                    , Chart.Attributes.size 4
+                                    ]
+                                    |> Chart.named aLabel
+                                ]
 
-                    y =
-                        Chart.Item.getY item
+                            Nothing ->
+                                []
+                       )
+                    ++ (case graph.set3Label of
+                            Just aLabel ->
+                                [ Chart.interpolatedMaybe (\item -> item.y3.count)
+                                    []
+                                    [ Chart.Attributes.circle, Chart.Attributes.size 3 ]
+                                    |> Chart.named aLabel
+                                ]
 
-                    tooltip =
-                        if data.y1.count == Just y then
-                            data.y1.tooltip
+                            Nothing ->
+                                []
+                       )
+                    ++ (case graph.set4Label of
+                            Just aLabel ->
+                                [ Chart.interpolatedMaybe (\item -> item.y4.count)
+                                    []
+                                    [ Chart.Attributes.circle, Chart.Attributes.size 3 ]
+                                    |> Chart.named aLabel
+                                ]
 
-                        else if data.y2.count == Just y then
-                            data.y2.tooltip
+                            Nothing ->
+                                []
+                       )
+                    ++ (case graph.set5Label of
+                            Just aLabel ->
+                                [ Chart.interpolatedMaybe (\item -> item.y5.count)
+                                    []
+                                    [ Chart.Attributes.circle, Chart.Attributes.size 3 ]
+                                    |> Chart.named aLabel
+                                ]
 
-                        else if data.y3.count == Just y then
-                            data.y3.tooltip
+                            Nothing ->
+                                []
+                       )
+                    ++ (case graph.set6Label of
+                            Just aLabel ->
+                                [ Chart.interpolatedMaybe (\item -> item.y6.count)
+                                    []
+                                    [ Chart.Attributes.circle, Chart.Attributes.size 3 ]
+                                    |> Chart.named aLabel
+                                ]
 
-                        else if data.y4.count == Just y then
-                            data.y4.tooltip
+                            Nothing ->
+                                []
+                       )
+                    ++ (case graph.set7Label of
+                            Just aLabel ->
+                                [ Chart.interpolatedMaybe (\item -> item.y7.count)
+                                    []
+                                    [ Chart.Attributes.circle, Chart.Attributes.size 3 ]
+                                    |> Chart.named aLabel
+                                ]
 
-                        else if data.y5.count == Just y then
-                            data.y5.tooltip
+                            Nothing ->
+                                []
+                       )
+                )
+                graph.dataPoints
+            , Chart.legendsAt .min
+                .max
+                [ Chart.Attributes.moveRight 50
+                , Chart.Attributes.spacing 15
+                , Chart.Attributes.moveUp 25
+                , Chart.Attributes.htmlAttrs [ Html.Attributes.class "chart-legend" ]
+                ]
+                []
+            , Chart.each model.chartHovering <|
+                \_ item ->
+                    let
+                        data =
+                            Chart.Item.getData item
 
-                        else if data.y6.count == Just y then
-                            data.y6.tooltip
+                        y =
+                            Chart.Item.getY item
 
-                        else if data.y7.count == Just y then
-                            data.y7.tooltip
+                        tooltip =
+                            if data.y1.count == Just y then
+                                data.y1.tooltip
 
-                        else
-                            ""
-                in
-                if String.length tooltip > 0 then
-                    [ Chart.tooltip item [] [] [ Html.text tooltip ] ]
+                            else if data.y2.count == Just y then
+                                data.y2.tooltip
 
-                else
-                    []
+                            else if data.y3.count == Just y then
+                                data.y3.tooltip
+
+                            else if data.y4.count == Just y then
+                                data.y4.tooltip
+
+                            else if data.y5.count == Just y then
+                                data.y5.tooltip
+
+                            else if data.y6.count == Just y then
+                                data.y6.tooltip
+
+                            else if data.y7.count == Just y then
+                                data.y7.tooltip
+
+                            else
+                                ""
+                    in
+                    if String.length tooltip > 0 then
+                        [ Chart.tooltip item [] [] [ Html.text tooltip ] ]
+
+                    else
+                        []
+            ]
         ]
 
 

--- a/src/elm/View/Graph.elm
+++ b/src/elm/View/Graph.elm
@@ -43,6 +43,7 @@ view model sectionId =
             ]
             [ Svg.text graph.title ]
         , Chart.xAxis [ Chart.Attributes.color "#FFFFFF" ]
+        , Chart.yAxis [ Chart.Attributes.color "#FFFFFF" ]
         , Chart.yLabels
             [ Chart.Attributes.format (\yLabel -> viewYLabel sectionId (String.fromFloat yLabel))
             , Chart.Attributes.color "#FFFFFF"

--- a/src/elm/View/Graph.elm
+++ b/src/elm/View/Graph.elm
@@ -260,27 +260,27 @@ dateRangeEnd id dataPoints =
         |> ceilingDate id
 
 
-oneYearInMiliseconds : Int
-oneYearInMiliseconds =
+oneYearInMillis : Int
+oneYearInMillis =
     31556952000
 
 
-oneWeekInMiliseconds : Int
-oneWeekInMiliseconds =
+oneWeekInMillis : Int
+oneWeekInMillis =
     604800000
 
 
 floorDate : Data.SectionId -> Float -> Float
-floorDate id milis =
+floorDate id millis =
     let
         unit =
             if id == Data.Section3 then
-                oneWeekInMiliseconds
+                oneWeekInMillis
 
             else
-                oneYearInMiliseconds
+                oneYearInMillis
     in
-    milis
+    millis
         |> floor
         |> (\time -> time // unit)
         |> (\units -> units * unit)
@@ -289,16 +289,16 @@ floorDate id milis =
 
 
 ceilingDate : Data.SectionId -> Float -> Float
-ceilingDate id milis =
+ceilingDate id millis =
     let
         unit =
             if id == Data.Section3 then
-                oneWeekInMiliseconds
+                oneWeekInMillis
 
             else
-                oneYearInMiliseconds
+                oneYearInMillis
     in
-    milis
+    millis
         |> floor
         |> (\time -> time // unit)
         |> (\units -> units * unit)

--- a/src/elm/View/Graph.elm
+++ b/src/elm/View/Graph.elm
@@ -70,86 +70,108 @@ view model sectionId =
                         ]
                         [ Svg.text (formatFullTime Time.utc info.timestamp) ]
                     ]
-            , Chart.series .x
-                ([ Chart.interpolatedMaybe (\item -> item.y1.count)
-                    [ Chart.Attributes.color "#E4003B" ]
-                    [ Chart.Attributes.color "#E40038"
-                    , Chart.Attributes.circle
-                    , Chart.Attributes.size 4
-                    ]
-                    |> Chart.named (Maybe.withDefault "" graph.set1Label)
-                 ]
-                    ++ (case graph.set2Label of
-                            Just aLabel ->
-                                [ Chart.interpolatedMaybe (\item -> item.y2.count)
-                                    [ Chart.Attributes.color "#0087DC" ]
-                                    [ Chart.Attributes.color "#0087DC"
-                                    , Chart.Attributes.circle
-                                    , Chart.Attributes.size 4
+            , if sectionId == Data.Section5 || sectionId == Data.Section2 then
+                Chart.series .x
+                    ([ Chart.interpolatedMaybe (\item -> item.y1.count)
+                        [ Chart.Attributes.color "#E4003B" ]
+                        [ Chart.Attributes.color "#E40038"
+                        , Chart.Attributes.circle
+                        , Chart.Attributes.size 4
+                        ]
+                        |> Chart.named (Maybe.withDefault "" graph.set1Label)
+                     ]
+                        ++ (case graph.set2Label of
+                                Just aLabel ->
+                                    [ Chart.interpolatedMaybe (\item -> item.y2.count)
+                                        [ Chart.Attributes.color "#0087DC" ]
+                                        [ Chart.Attributes.color "#0087DC"
+                                        , Chart.Attributes.circle
+                                        , Chart.Attributes.size 4
+                                        ]
+                                        |> Chart.named aLabel
                                     ]
-                                    |> Chart.named aLabel
-                                ]
 
-                            Nothing ->
-                                []
-                       )
-                    ++ (case graph.set3Label of
-                            Just aLabel ->
-                                [ Chart.interpolatedMaybe (\item -> item.y3.count)
+                                Nothing ->
                                     []
-                                    [ Chart.Attributes.circle, Chart.Attributes.size 3 ]
-                                    |> Chart.named aLabel
-                                ]
+                           )
+                    )
+                    graph.dataPoints
 
-                            Nothing ->
-                                []
-                       )
-                    ++ (case graph.set4Label of
-                            Just aLabel ->
-                                [ Chart.interpolatedMaybe (\item -> item.y4.count)
+              else
+                Chart.series .x
+                    ([ Chart.interpolatedMaybe (\item -> item.y1.count)
+                        []
+                        [ Chart.Attributes.circle, Chart.Attributes.size 3 ]
+                        |> Chart.named (Maybe.withDefault "" graph.set1Label)
+                     ]
+                        ++ (case graph.set2Label of
+                                Just aLabel ->
+                                    [ Chart.interpolatedMaybe (\item -> item.y2.count)
+                                        []
+                                        [ Chart.Attributes.circle, Chart.Attributes.size 3 ]
+                                        |> Chart.named aLabel
+                                    ]
+
+                                Nothing ->
                                     []
-                                    [ Chart.Attributes.circle, Chart.Attributes.size 3 ]
-                                    |> Chart.named aLabel
-                                ]
+                           )
+                        ++ (case graph.set3Label of
+                                Just aLabel ->
+                                    [ Chart.interpolatedMaybe (\item -> item.y3.count)
+                                        []
+                                        [ Chart.Attributes.circle, Chart.Attributes.size 3 ]
+                                        |> Chart.named aLabel
+                                    ]
 
-                            Nothing ->
-                                []
-                       )
-                    ++ (case graph.set5Label of
-                            Just aLabel ->
-                                [ Chart.interpolatedMaybe (\item -> item.y5.count)
+                                Nothing ->
                                     []
-                                    [ Chart.Attributes.circle, Chart.Attributes.size 3 ]
-                                    |> Chart.named aLabel
-                                ]
+                           )
+                        ++ (case graph.set4Label of
+                                Just aLabel ->
+                                    [ Chart.interpolatedMaybe (\item -> item.y4.count)
+                                        []
+                                        [ Chart.Attributes.circle, Chart.Attributes.size 3 ]
+                                        |> Chart.named aLabel
+                                    ]
 
-                            Nothing ->
-                                []
-                       )
-                    ++ (case graph.set6Label of
-                            Just aLabel ->
-                                [ Chart.interpolatedMaybe (\item -> item.y6.count)
+                                Nothing ->
                                     []
-                                    [ Chart.Attributes.circle, Chart.Attributes.size 3 ]
-                                    |> Chart.named aLabel
-                                ]
+                           )
+                        ++ (case graph.set5Label of
+                                Just aLabel ->
+                                    [ Chart.interpolatedMaybe (\item -> item.y5.count)
+                                        []
+                                        [ Chart.Attributes.circle, Chart.Attributes.size 3 ]
+                                        |> Chart.named aLabel
+                                    ]
 
-                            Nothing ->
-                                []
-                       )
-                    ++ (case graph.set7Label of
-                            Just aLabel ->
-                                [ Chart.interpolatedMaybe (\item -> item.y7.count)
+                                Nothing ->
                                     []
-                                    [ Chart.Attributes.circle, Chart.Attributes.size 3 ]
-                                    |> Chart.named aLabel
-                                ]
+                           )
+                        ++ (case graph.set6Label of
+                                Just aLabel ->
+                                    [ Chart.interpolatedMaybe (\item -> item.y6.count)
+                                        []
+                                        [ Chart.Attributes.circle, Chart.Attributes.size 3 ]
+                                        |> Chart.named aLabel
+                                    ]
 
-                            Nothing ->
-                                []
-                       )
-                )
-                graph.dataPoints
+                                Nothing ->
+                                    []
+                           )
+                        ++ (case graph.set7Label of
+                                Just aLabel ->
+                                    [ Chart.interpolatedMaybe (\item -> item.y7.count)
+                                        []
+                                        [ Chart.Attributes.circle, Chart.Attributes.size 3 ]
+                                        |> Chart.named aLabel
+                                    ]
+
+                                Nothing ->
+                                    []
+                           )
+                    )
+                    graph.dataPoints
             , Chart.legendsAt .min
                 .max
                 [ Chart.Attributes.moveRight 50

--- a/src/elm/View/Section2.elm
+++ b/src/elm/View/Section2.elm
@@ -16,7 +16,7 @@ view model =
         [ Html.Attributes.class "graph-container"
         , Html.Attributes.style "min-height" (String.fromFloat (Tuple.first model.viewportHeightWidth) ++ "px")
         ]
-        [ Html.div [ Html.Attributes.class "chart" ] [ View.Graph.view model Data.Section2 ]
+        [ View.Graph.view model Data.Section2
         ]
     , View.MainText.viewBottom Data.Section2 model.content.mainText
     ]

--- a/src/elm/View/Section3.elm
+++ b/src/elm/View/Section3.elm
@@ -16,7 +16,7 @@ view model =
         [ Html.Attributes.class "graph-container"
         , Html.Attributes.style "min-height" (String.fromFloat (Tuple.first model.viewportHeightWidth) ++ "px")
         ]
-        [ Html.div [ Html.Attributes.class "chart" ] [ View.Graph.view model Data.Section3 ]
+        [ View.Graph.view model Data.Section3
         ]
     , View.MainText.viewBottom Data.Section3 model.content.mainText
     ]

--- a/src/elm/View/Section5.elm
+++ b/src/elm/View/Section5.elm
@@ -16,7 +16,7 @@ view model =
         [ Html.Attributes.class "graph-container"
         , Html.Attributes.style "min-height" (String.fromFloat (Tuple.first model.viewportHeightWidth) ++ "px")
         ]
-        [ Html.div [ Html.Attributes.class "chart" ] [ View.Graph.view model Data.Section5 ]
+        [ View.Graph.view model Data.Section5
         ]
     , View.MainText.viewBottom Data.Section5 model.content.mainText
     ]


### PR DESCRIPTION
Fixes #255

## Description

- calculate size of longest y axis label and add padding to container, this pushes everything in the right direction but as it uses `ch` units which are based off the base font size it will only fall into perfect alignment at a sweetspot as the SVG text grows and shrinks with the screen size.
- legend now limited to 90% of the svg width and wraps on to a new line when it needs to, conveniently you can pass arbitrary html attributes to this so could just add a class and use normal CSS
- I've switched all the fonts to `TT firs neue`, unfortunately I wasn't able to target just the title. You can't pass in a class and for some reason `first-child` didn't seem to effect it. Hopefully this is an improvement
- A buffer of time is applied to the X axis
- Section 2 and 5 get the chosen colors, the telegram graph reverts to defaults which I think just evenly spaces the color spectrum to get better separation.
- I reduced the number of generated X axis label points because when I added in the time buffer the graph that spanned more years started to have overlapping labels
- I looked into forcing a vertical line on the right hand side, it wasn't possible in the chart library. It was possible to add a single border with CSS but it looked worse than leaving it out.

I think that covers all the issues with a couple of compromises!

![image](https://github.com/user-attachments/assets/ea79003b-cc9a-4394-8edb-251d1a67c948)
