### PR TITLE
make draggable images smaller and without invisble parts that can

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -739,8 +739,8 @@ h2.final-ticker {
 }
 
 .image-constraint {
-  height: 60vh;
-  width: 40vw;
+  max-height: 60vh;
+  width: 30vw;
 }
 
 .post-draggable {


### PR DESCRIPTION
Make draggable images smaller (now we don't have PNGs with clear bits) and fix invisible parts that can trigger dragging and confuse users
