### PR TITLE
fix: Add section tracker to trigger hyvor comment reload

### DIFF
--- a/src/elm/View/Context.elm
+++ b/src/elm/View/Context.elm
@@ -57,6 +57,9 @@ viewContextSection context =
             , Html.Attributes.attribute "page-id" (sectionIdStringFromSection context.section)
             ]
             []
+        , Html.node "section-change-tracker"
+            [ Html.Attributes.attribute "section-id" (sectionIdStringFromSection context.section) ]
+            []
         ]
 
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -38,6 +38,24 @@ const app = Elm.Main.init({
   },
 });
 
+
+customElements.define("section-change-tracker", class extends HTMLElement {
+  
+  constructor() { super(); }
+  
+  static get observedAttributes() { return ["section-id"]; }
+  
+  attributeChangedCallback(name, oldValue, newValue) {
+    if (name === "section-id" && oldValue !== newValue) {
+      const comments = document.querySelector("hyvor-talk-comments");
+      if (comments !== null) {
+        comments.api.reload();
+      }
+    }
+  }
+});
+
+
 window.addEventListener("scroll", () => {
   app.ports.onScroll.send({ x: window.scrollX, y: window.scrollY });
 });


### PR DESCRIPTION
Fixes #21

## Description

- Track changes to section id and call reload for hyvor
