### PR TITLE
Use correct id for ticker section

### DIFF
--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -161,10 +161,10 @@ update msg model =
                 | time = newTime
                 , tickerState =
                     let
-                        section8InView =
-                            InView.isInOrAboveView "section-eleven" model.inView |> Maybe.withDefault False
+                        tickerSectionInView =
+                            InView.isInOrAboveView "data-loss" model.inView |> Maybe.withDefault False
                     in
-                    if section8InView then
+                    if tickerSectionInView then
                         List.map (\tickerState -> Data.updateTickerState tickerState) model.tickerState
 
                     else


### PR DESCRIPTION
Fixes #272

## Description

- Rename section lookup to named from legacy numbered
