### PR TITLE
Feat/282 move intro to own page

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -58,11 +58,11 @@ a:focus {
 }
 
 #introduction {
+  background-color: var(--white);
   padding-top: 0;
 }
 
 #introduction .introduction {
-  background-color: var(--white);
   color: var(--black);
   margin-left: calc(50% - 50vw);
   margin-right: calc(50% - 50vw);

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -73,6 +73,13 @@ a:focus {
   background: none;
 }
 
+#introduction a {
+  background-color: var(--black);
+  cursor: pointer;
+  padding: 1rem 2rem;
+  text-decoration: none;
+}
+
 #ulterior-motives,
 #public-order-safety .graph-container,
 #panic-lit,
@@ -125,13 +132,31 @@ a:focus {
   outline: var(--blue) solid 5px;
 }
 
+.context-header {
+  align-items: center;
+  display: flex;
+  justify-content: end;
+}
+
+.context-header a {
+  color: var(--black);
+  cursor: pointer;
+  font-size: 0.75rem;
+  padding: 1rem 0;
+  text-decoration: underline;
+}
+
+.context-header a,
 .context-section-title {
   font-family: "TT Firs Neue Var Roman", Inter, Roboto, "Helvetica Neue",
     "Arial Nova", "Nimbus Sans", Arial, sans-serif;
-  font-size: 0.875rem;
   font-weight: bold;
-  padding: 1rem 1.5rem;
   text-align: right;
+}
+
+.context-section-title {
+  font-size: 0.875rem;
+  padding: 1rem 1.5rem;
 }
 
 .context-summary {

--- a/src/elm/Copy/Keys.elm
+++ b/src/elm/Copy/Keys.elm
@@ -3,6 +3,8 @@ module Copy.Keys exposing (Key(..))
 
 type Key
     = SiteTitle
+      -- Intro
+    | ViewContentButtonLabel
       -- Context
     | ContextLabel
     | ContextNewSectionMessage

--- a/src/elm/Copy/Keys.elm
+++ b/src/elm/Copy/Keys.elm
@@ -4,7 +4,8 @@ module Copy.Keys exposing (Key(..))
 type Key
     = SiteTitle
       -- Intro
-    | ViewContentButtonLabel
+    | ViewContentLinkText
+    | ViewIntroLinkText
       -- Context
     | ContextLabel
     | ContextNewSectionMessage

--- a/src/elm/Copy/Text.elm
+++ b/src/elm/Copy/Text.elm
@@ -14,6 +14,9 @@ t key =
         SiteTitle ->
             "Bifurcated"
 
+        ViewContentButtonLabel ->
+            "Explore content"
+
         ContextLabel ->
             "Context"
 

--- a/src/elm/Copy/Text.elm
+++ b/src/elm/Copy/Text.elm
@@ -14,8 +14,11 @@ t key =
         SiteTitle ->
             "Bifurcated"
 
-        ViewContentButtonLabel ->
+        ViewContentLinkText ->
             "Explore content"
+
+        ViewIntroLinkText ->
+            "View intro"
 
         ContextLabel ->
             "Context"

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -112,6 +112,7 @@ init flags =
     in
     ( { time = Time.millisToPosix 0
       , content = content
+      , viewingIntro = True
       , tickerState = initialTickerState
       , breachCount = 0
       , domHeight = 0.0
@@ -188,6 +189,13 @@ update msg model =
         GotViewport viewport ->
             ( { model | viewportHeightWidth = Maybe.withDefault model.viewportHeightWidth (Just ( viewport.viewport.height, viewport.viewport.width )) }
             , Cmd.none
+            )
+
+        ToggleViewIntro ->
+            ( { model
+                | viewingIntro = not model.viewingIntro
+              }
+            , Task.perform (always NoOp) (Browser.Dom.setViewport 0 0)
             )
 
         OnScroll offset ->
@@ -274,7 +282,7 @@ update msg model =
                         )
                         model.terminalState
               }
-              --       -- maybe playing with this will help
+              -- maybe playing with this will help
             , scrollToElement "terminal-output"
             )
 

--- a/src/elm/Model.elm
+++ b/src/elm/Model.elm
@@ -11,6 +11,7 @@ import Time
 type alias Model =
     { time : Time.Posix
     , content : Data.Content
+    , viewingIntro : Bool
     , tickerState : List Data.TickerState
     , breachCount : Int
     , randomIntList : List Int

--- a/src/elm/Msg.elm
+++ b/src/elm/Msg.elm
@@ -12,6 +12,7 @@ type Msg
     = NoOp
     | Tick Time.Posix
     | NewRandomIntList (List Int)
+    | ToggleViewIntro
     | OnScroll { x : Float, y : Float }
     | OnGrow Float
     | OnResize ( Float, Float )

--- a/src/elm/View.elm
+++ b/src/elm/View.elm
@@ -28,25 +28,28 @@ import View.Section.UlteriorMotives
 
 sectionViews : Model -> List ( Data.SectionId, List (Html.Html Msg) )
 sectionViews model =
-    [ ( Data.Introduction, View.Section.Introduction.view model )
-    , ( Data.SocialMediaPosts, View.Section.SocialMediaPosts.view model )
-    , ( Data.PublicTrust, View.Section.PublicTrust.view model )
-    , ( Data.Telegram, View.Section.Telegram.view model )
-    , ( Data.UlteriorMotives, View.Section.UlteriorMotives.view model )
-    , ( Data.PanicLit, View.Section.PanicLit.view model )
-    , ( Data.PublicOrderSafety, View.Section.PublicOrderSafety.view model )
-    , ( Data.DisproportionateEssayEnd, View.Section.DisproportionateEssayEnd.view model )
-    , ( Data.FacialRecognition, View.Section.FacialRecognition.view model )
-    , ( Data.IncompetenceIntro, View.Section.IncompetenceIntro.view model )
-    , ( Data.IncompetencePostsAndPapers, View.Section.IncompetencePostsAndPapers.view model )
-    , ( Data.HmrcTerminal, View.Section.HmrcTerminal.view model )
-    , ( Data.DataLoss, View.Section.DataLoss.view model )
-    , ( Data.RansomwareTerminal, View.Section.RansomwareTerminal.view model )
-    , ( Data.HumanCost, View.Section.HumanCost.view model )
-    , ( Data.RoyalMailNegotiation, View.Section.RoyalMailNegotiation.view model )
-    , ( Data.HackneySocial, View.Section.HackneySocial.view model )
-    , ( Data.Outro, View.Section.Outro.view model )
-    ]
+    if model.viewingIntro then
+        [ ( Data.Introduction, View.Section.Introduction.view model ) ]
+
+    else
+        [ ( Data.SocialMediaPosts, View.Section.SocialMediaPosts.view model )
+        , ( Data.PublicTrust, View.Section.PublicTrust.view model )
+        , ( Data.Telegram, View.Section.Telegram.view model )
+        , ( Data.UlteriorMotives, View.Section.UlteriorMotives.view model )
+        , ( Data.PanicLit, View.Section.PanicLit.view model )
+        , ( Data.PublicOrderSafety, View.Section.PublicOrderSafety.view model )
+        , ( Data.DisproportionateEssayEnd, View.Section.DisproportionateEssayEnd.view model )
+        , ( Data.FacialRecognition, View.Section.FacialRecognition.view model )
+        , ( Data.IncompetenceIntro, View.Section.IncompetenceIntro.view model )
+        , ( Data.IncompetencePostsAndPapers, View.Section.IncompetencePostsAndPapers.view model )
+        , ( Data.HmrcTerminal, View.Section.HmrcTerminal.view model )
+        , ( Data.DataLoss, View.Section.DataLoss.view model )
+        , ( Data.RansomwareTerminal, View.Section.RansomwareTerminal.view model )
+        , ( Data.HumanCost, View.Section.HumanCost.view model )
+        , ( Data.RoyalMailNegotiation, View.Section.RoyalMailNegotiation.view model )
+        , ( Data.HackneySocial, View.Section.HackneySocial.view model )
+        , ( Data.Outro, View.Section.Outro.view model )
+        ]
 
 
 viewSections : Model -> List (Html.Html Msg)

--- a/src/elm/View/Context.elm
+++ b/src/elm/View/Context.elm
@@ -5,9 +5,10 @@ import Copy.Text exposing (t)
 import Data
 import Html
 import Html.Attributes
+import Html.Events
 import InView
 import Markdown
-import Msg exposing (Msg)
+import Msg exposing (Msg(..))
 
 
 view : InView.State -> List Data.Context -> Html.Html Msg
@@ -70,15 +71,24 @@ sectionIdStringFromSection sectionId =
 
 viewContextSectionHeader : Data.SectionId -> Html.Html Msg
 viewContextSectionHeader sectionId =
-    Html.h2
-        [ Html.Attributes.class "context-section-title"
-        , Html.Attributes.attribute "aria-live" "polite"
-        ]
-        [ Html.span
-            [ Html.Attributes.class "screen-reader-only"
+    Html.div [ Html.Attributes.class "context-header" ]
+        [ Html.a [ Html.Events.onClick ToggleViewIntro ]
+            [ if sectionId == Data.Introduction then
+                Html.text (t ViewContentLinkText)
+
+              else
+                Html.text (t ViewIntroLinkText)
             ]
-            [ Html.text (t ContextNewSectionMessage) ]
-        , Html.text ("Section " ++ String.fromInt (Data.sectionIdToInt sectionId) ++ " of 18")
+        , Html.h2
+            [ Html.Attributes.class "context-section-title"
+            , Html.Attributes.attribute "aria-live" "polite"
+            ]
+            [ Html.span
+                [ Html.Attributes.class "screen-reader-only"
+                ]
+                [ Html.text (t ContextNewSectionMessage) ]
+            , Html.text ("Section " ++ String.fromInt (Data.sectionIdToInt sectionId) ++ " of 18")
+            ]
         ]
 
 

--- a/src/elm/View/Section/Introduction.elm
+++ b/src/elm/View/Section/Introduction.elm
@@ -4,6 +4,7 @@ import Copy.Keys exposing (Key(..))
 import Copy.Text exposing (t)
 import Data
 import Html
+import Html.Attributes
 import Html.Events
 import Model exposing (Model)
 import Msg exposing (Msg(..))
@@ -16,5 +17,8 @@ import View.Posts
 view : Model -> List (Html.Html Msg)
 view model =
     [ View.MainText.viewTop Data.Introduction model.content.mainText
-    , Html.button [ Html.Events.onClick ToggleViewIntro ] [ Html.text (t ViewContentButtonLabel) ]
+    , Html.a
+        [ Html.Events.onClick ToggleViewIntro
+        ]
+        [ Html.text (t ViewContentLinkText) ]
     ]

--- a/src/elm/View/Section/Introduction.elm
+++ b/src/elm/View/Section/Introduction.elm
@@ -1,7 +1,10 @@
 module View.Section.Introduction exposing (view)
 
+import Copy.Keys exposing (Key(..))
+import Copy.Text exposing (t)
 import Data
 import Html
+import Html.Events
 import Model exposing (Model)
 import Msg exposing (Msg(..))
 import Pile
@@ -13,4 +16,5 @@ import View.Posts
 view : Model -> List (Html.Html Msg)
 view model =
     [ View.MainText.viewTop Data.Introduction model.content.mainText
+    , Html.button [ Html.Events.onClick ToggleViewIntro ] [ Html.text (t ViewContentButtonLabel) ]
     ]


### PR DESCRIPTION
Fixes #282

## Description

- Adds a button to view content after intro section
- Adds ability to toggle between intro and content from context menu header
- Styling TBC

It made sense to me to have the toggle to explore content in the context menu since it was there to get back to intro.

I'm not sure on the accessibility of the a tags but this seems to work best in terms of UX. See what you think.