### PR TITLE
feat: Hack footer template into index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ We're using elm-test-rs(https://github.com/mpizenberg/elm-test-rs) to run [elm t
 
 - Assets to be copied to deploy bundle root are in `public/`
 - Markdown content is in `content/` and compiled to `data/*.json` files with `npm run generate`
+- Html added between `<template>` tags in [index.html](/index.html) will render in `<footer>`
 
 
 ### Styling & layouts

--- a/index.html
+++ b/index.html
@@ -20,7 +20,6 @@
 <meta property="og:description" content="Bi4c8d tries to understand how specific events have contributed to the decline in institutional trust, and why the conspiratorial rabbit hole is overflowing.">
     <template>
     <!-- Add html markup to display in <footer></footer> -->
-    [cCc] Temp footer markup [cCc]
     </template>
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -18,6 +18,10 @@
 <meta property="og:url" content="https://bifurcated.uk">
 <meta property="og:image" content="https://bifurcated.carrd.co/assets/images/image01.jpg?v=55d8920f">
 <meta property="og:description" content="Bi4c8d tries to understand how specific events have contributed to the decline in institutional trust, and why the conspiratorial rabbit hole is overflowing.">
+    <template>
+    <!-- Add html markup to display in <footer></footer> -->
+    [cCc] Temp footer markup [cCc]
+    </template>
   </head>
   <body>
     <div id="app">

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -344,6 +344,7 @@ viewDocument model =
                     ]
                 ]
             , Html.div [] (View.viewSections model)
+            , Html.footer [ Html.Attributes.id "footer" ] []
             ]
         ]
     }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -42,6 +42,14 @@ const app = Elm.Main.init({
   },
 });
 
+const footer = document.querySelector("#footer");
+footer.append(
+  document.importNode(
+    document.querySelector('template').content,
+    true
+  )
+);
+
 
 customElements.define("hyvor-talk-comments-wrapper", class extends HTMLElement {
 


### PR DESCRIPTION
Fixes #322 

## Description

- Add template to index `head`
- Add `footer` section
- Render content of `template` in the footer 
