### PR TITLE
fix: Do not show current page info on Project Information page

### DIFF
--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -355,7 +355,11 @@ viewPageNavigation currentView =
     in
     Html.nav [ Html.Attributes.class "pagination" ]
         [ viewNextPreviousLink previousPage "Previous"
-        , Html.text (t (CurrentViewText currentView))
+        , if not (currentView == ProjectInfo) then
+            Html.text (t (CurrentViewText currentView))
+
+          else
+            Html.text ""
         , viewNextPreviousLink nextPage "Next"
         ]
 


### PR DESCRIPTION
Fixes - bug where project info used to say "Page Project Information of 7" in the footer
